### PR TITLE
#4 sort namespaces and pods according to their labels

### DIFF
--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/KubernetesTreeStructure.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/KubernetesTreeStructure.kt
@@ -44,7 +44,7 @@ class KubernetesTreeStructure(private val project: Project) : AbstractTreeStruct
                         Categories.NODES,
                         Categories.WORKLOADS)
                 Categories.NAMESPACES ->
-                    getResourceModel().getAllNamespaces().toTypedArray()
+                    getResourceModel().getAllNamespaces().sortedBy { it.metadata.name }.toTypedArray()
                 Categories.NODES ->
                     emptyArray()
                 Categories.WORKLOADS ->
@@ -52,7 +52,7 @@ class KubernetesTreeStructure(private val project: Project) : AbstractTreeStruct
                 Categories.PODS -> {
                     getResourceModel().getResources(
                         getResourceModel().getCurrentNamespace()?.metadata?.name,
-                        PodsProvider.KIND)
+                        PodsProvider.KIND).sortedBy { it.metadata.name }
                         .toTypedArray()
                 }
                 else ->


### PR DESCRIPTION
Signed-off-by: Dmitrii Bocharov <bdshadow@gmail.com>

also sorted the namespaces accordingly.

The sorting also can be done by passing a Comparator to `StructureTreeModel` in `KubernetesToolWindowFactory`, but it will be applied to the whole tree, as far as I understand. So I thought that sorting it separately is better. Correct me, please, if I'm wrong, I'll fix it.