### PR TITLE
display endpoints (#58)

### DIFF
--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/KubernetesContext.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/KubernetesContext.kt
@@ -18,6 +18,7 @@ import org.jboss.tools.intellij.kubernetes.model.IModelChangeObservable
 import org.jboss.tools.intellij.kubernetes.model.context.IActiveContext.*
 import org.jboss.tools.intellij.kubernetes.model.resource.IResourcesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.AllPodsProvider
+import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.EndpointsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.NamespacesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.NodesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.NamespacedPodsProvider
@@ -36,7 +37,8 @@ open class KubernetesContext(
 				NodesProvider(client),
 				AllPodsProvider(client),
 				NamespacedPodsProvider(client),
-				ServicesProvider(client)
+				ServicesProvider(client),
+				EndpointsProvider(client)
 		)
 	}
 

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/OpenShiftContext.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/OpenShiftContext.kt
@@ -18,6 +18,7 @@ import org.jboss.tools.intellij.kubernetes.model.IModelChangeObservable
 import org.jboss.tools.intellij.kubernetes.model.context.IActiveContext.*
 import org.jboss.tools.intellij.kubernetes.model.resource.IResourcesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.AllPodsProvider
+import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.EndpointsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.NamespacesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.NodesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.NamespacedPodsProvider
@@ -44,7 +45,8 @@ open class OpenShiftContext(
 				ImageStreamsProvider(client),
 				DeploymentConfigsProvider(client),
 				ReplicationControllersProvider(client),
-				ServicesProvider(client)
+				ServicesProvider(client),
+				EndpointsProvider(client)
 		)
 	}
 

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/EndpointsProvider.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/EndpointsProvider.kt
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.kubernetes.model.resource.kubernetes
+
+import io.fabric8.kubernetes.api.model.Endpoints
+import io.fabric8.kubernetes.api.model.Service
+import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient
+import io.fabric8.kubernetes.client.Watch
+import io.fabric8.kubernetes.client.Watcher
+import io.fabric8.kubernetes.client.dsl.Watchable
+import io.fabric8.openshift.api.model.DeploymentConfig
+import io.fabric8.openshift.client.NamespacedOpenShiftClient
+import org.jboss.tools.intellij.kubernetes.model.resource.NamespacedResourcesProvider
+
+class EndpointsProvider(client: KubernetesClient)
+    : NamespacedResourcesProvider<Endpoints, KubernetesClient>(client) {
+
+    companion object {
+        val KIND = Endpoints::class.java;
+    }
+
+    override val kind = KIND
+
+    override fun loadAllResources(namespace: String): List<Endpoints> {
+        return client.endpoints().inNamespace(namespace).list().items
+    }
+
+    override fun getWatchableResource(namespace: String): () -> Watchable<Watch, Watcher<Endpoints>>? {
+        return { client.endpoints().inNamespace(namespace) }
+    }
+
+}

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/OpenShiftStructure.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/OpenShiftStructure.kt
@@ -23,6 +23,9 @@ import org.jboss.tools.intellij.kubernetes.model.resourceName
 import org.jboss.tools.intellij.kubernetes.model.context.OpenShiftContext
 import org.jboss.tools.intellij.kubernetes.model.resource.DeploymentConfigFor
 import org.jboss.tools.intellij.kubernetes.model.resource.ReplicationControllerFor
+import org.jboss.tools.intellij.kubernetes.tree.TreeStructure.Folder
+import org.jboss.tools.intellij.kubernetes.tree.TreeStructure.Descriptor
+import org.jboss.tools.intellij.kubernetes.tree.TreeStructure.ResourceDescriptor
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.NODES
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.WORKLOADS
 import javax.swing.Icon
@@ -30,9 +33,9 @@ import javax.swing.Icon
 class OpenShiftStructure(model: IResourceModel): AbstractTreeStructureContribution(model) {
 
     companion object Folders {
-        val PROJECTS = TreeStructure.Folder("Projects", Project::class.java)
-        val IMAGESTREAMS = TreeStructure.Folder("ImageStreams", ImageStream::class.java)
-        val DEPLOYMENTCONFIGS = TreeStructure.Folder("DeploymentConfigs", DeploymentConfig::class.java)
+        val PROJECTS = Folder("Projects", Project::class.java)
+        val IMAGESTREAMS = Folder("ImageStreams", ImageStream::class.java)
+        val DEPLOYMENTCONFIGS = Folder("DeploymentConfigs", DeploymentConfig::class.java)
     }
 
     override fun canContribute(): Boolean {
@@ -117,21 +120,22 @@ class OpenShiftStructure(model: IResourceModel): AbstractTreeStructureContributi
         }
     }
 
-    private class OpenShiftContextDescriptor(context: OpenShiftContext, model: IResourceModel) : TreeStructure.ContextDescriptor<OpenShiftContext>(
-        context = context,
-        model = model
+    private class OpenShiftContextDescriptor(context: OpenShiftContext, model: IResourceModel)
+        : TreeStructure.ContextDescriptor<OpenShiftContext>(
+            context = context,
+            model = model
     ) {
         override fun getIcon(element: OpenShiftContext): Icon? {
             return IconLoader.getIcon("/icons/openshift-cluster.svg")
         }
     }
 
-    private class ProjectDescriptor(element: Project, parent: NodeDescriptor<*>?, model: IResourceModel) : TreeStructure.Descriptor<Project>(
-            element,
-            parent,
-            model
+    private class ProjectDescriptor(
+            element: Project,
+            parent: NodeDescriptor<*>?,
+            model: IResourceModel)
+        : ResourceDescriptor<Project>(element, parent, model) {
 
-    ) {
         override fun getLabel(element: Project): String {
             var label = element.metadata.name
             if (label == model.getCurrentNamespace()) {
@@ -139,51 +143,23 @@ class OpenShiftStructure(model: IResourceModel): AbstractTreeStructureContributi
             }
             return label
         }
-
-        override fun getIcon(element: Project): Icon? {
-            return IconLoader.getIcon("/icons/project.png")
-        }
     }
 
-    private class ImageStreamDescriptor(element: ImageStream, parent: NodeDescriptor<*>?, model: IResourceModel) : TreeStructure.Descriptor<ImageStream>(
-            element,
-            parent,
-            model
-    ) {
-        override fun getLabel(element: ImageStream): String {
-            return element.metadata.name
-        }
+    private class ImageStreamDescriptor(
+            element: ImageStream,
+            parent: NodeDescriptor<*>?,
+            model: IResourceModel)
+        : ResourceDescriptor<ImageStream>(element, parent,model)
 
-        override fun getIcon(element: ImageStream): Icon? {
-            return IconLoader.getIcon("/icons/project.png")
-        }
-    }
+    private class DeploymentConfigDescriptor(
+            element: DeploymentConfig,
+            parent: NodeDescriptor<*>?,
+            model: IResourceModel)
+        : ResourceDescriptor<DeploymentConfig>(element, parent, model)
 
-    private class DeploymentConfigDescriptor(element: DeploymentConfig, parent: NodeDescriptor<*>?, model: IResourceModel) : TreeStructure.Descriptor<DeploymentConfig>(
-            element,
-            parent,
-            model
-    ) {
-        override fun getLabel(element: DeploymentConfig): String {
-            return element.metadata.name
-        }
-
-        override fun getIcon(element: DeploymentConfig): Icon? {
-            return IconLoader.getIcon("/icons/project.png")
-        }
-    }
-
-    private class ReplicationControllerDescriptor(element: ReplicationController, parent: NodeDescriptor<*>?, model: IResourceModel) : TreeStructure.Descriptor<ReplicationController>(
-            element,
-            parent,
-            model
-    ) {
-        override fun getLabel(element: ReplicationController): String {
-            return element.metadata.name
-        }
-
-        override fun getIcon(element: ReplicationController): Icon? {
-            return IconLoader.getIcon("/icons/project.png")
-        }
-    }
+    private class ReplicationControllerDescriptor(
+            element: ReplicationController,
+            parent: NodeDescriptor<*>?,
+            model: IResourceModel)
+        : ResourceDescriptor<ReplicationController>(element, parent,model)
 }

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/TreeStructure.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/TreeStructure.kt
@@ -194,6 +194,16 @@ open class TreeStructure(
         }
     }
 
+    open class ResourceDescriptor<T: HasMetadata>(
+            element: T,
+            parent: NodeDescriptor<*>?,
+            model: IResourceModel): Descriptor<T>(element, parent, model) {
+
+        override fun getLabel(element: T): String {
+            return element.metadata.name
+        }
+    }
+
     open class Descriptor<T>(
             element: T,
             parent: NodeDescriptor<*>?,
@@ -220,7 +230,7 @@ open class TreeStructure(
         }
 
         protected open fun getLabel(element: T): String {
-            return element?.toString() ?: ""
+            return element.toString()
         }
 
         protected open fun getIcon(element: T): Icon? {


### PR DESCRIPTION
fixes #58 
depends on #57  

Here's how endpoints are displayed with this PR:
![image](https://user-images.githubusercontent.com/25126/85070396-06889500-b1b6-11ea-8059-50480ac1f9be.png)

In comparison how vscode is displaying them:
![image](https://user-images.githubusercontent.com/25126/85070435-143e1a80-b1b6-11ea-88d7-73be7383e96c.png)
