### PR TITLE
Show StatefulSets (#68)

### DIFF
--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/KubernetesContext.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/KubernetesContext.kt
@@ -30,6 +30,7 @@ import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.PersistentV
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.PersistentVolumesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.SecretsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.ServicesProvider
+import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.StatefulSetsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.StorageClassesProvider
 
 open class KubernetesContext(
@@ -44,6 +45,7 @@ open class KubernetesContext(
 				NamespacesProvider(client),
 				NodesProvider(client),
 				AllPodsProvider(client),
+				StatefulSetsProvider(client),
 				NamespacedPodsProvider(client),
 				ServicesProvider(client),
 				EndpointsProvider(client),

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/OpenShiftContext.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/OpenShiftContext.kt
@@ -28,6 +28,7 @@ import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.PersistentV
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.PersistentVolumesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.SecretsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.ServicesProvider
+import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.StatefulSetsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.StorageClassesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.openshift.DeploymentConfigsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.openshift.ImageStreamsProvider
@@ -46,6 +47,7 @@ open class OpenShiftContext(
 				NamespacesProvider(client),
 				NodesProvider(client),
 				AllPodsProvider(client),
+				StatefulSetsProvider(client),
 				NamespacedPodsProvider(client),
 				ProjectsProvider(client),
 				ImageStreamsProvider(client),

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/Filters.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/Filters.kt
@@ -13,6 +13,7 @@ package org.jboss.tools.intellij.kubernetes.model.resource
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.Service
+import io.fabric8.kubernetes.api.model.apps.StatefulSet
 import io.fabric8.openshift.api.model.DeploymentConfig
 import java.util.function.Predicate
 
@@ -40,5 +41,12 @@ class PodForService(private val service: Service) : Predicate<Pod> {
 
 	override fun test(pod: Pod): Boolean {
 		return service.spec.selector.all { pod.metadata.labels.entries.contains(it) }
+	}
+}
+
+class PodForStatefulSet(private val statefulSet: StatefulSet) : Predicate<Pod> {
+
+	override fun test(pod: Pod): Boolean {
+		return statefulSet.spec.selector.matchLabels.all { pod.metadata.labels.entries.contains(it) }
 	}
 }

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/AdaptedClient.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/AdaptedClient.kt
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.kubernetes.model.resource.kubernetes
+
+import io.fabric8.kubernetes.client.Client
+import io.fabric8.kubernetes.client.KubernetesClient
+
+interface IAdaptedClient<C: Client> {
+    val adaptedClient: C
+}
+
+class AdaptedClient<C: Client>(client: KubernetesClient, adapter: Class<C>): IAdaptedClient<C> {
+    override val adaptedClient: C = client.adapt(adapter)
+}

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/DaemonSetsProvider.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/DaemonSetsProvider.kt
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.kubernetes.model.resource.kubernetes
+
+import io.fabric8.kubernetes.api.model.extensions.Ingress
+import io.fabric8.kubernetes.client.ExtensionsAPIGroupClient
+import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.Watch
+import io.fabric8.kubernetes.client.Watcher
+import io.fabric8.kubernetes.client.dsl.Watchable
+import org.jboss.tools.intellij.kubernetes.model.resource.NamespacedResourcesProvider
+
+class IngressProvider(client: KubernetesClient)
+    : NamespacedResourcesProvider<Ingress, KubernetesClient>(client) {
+
+    companion object {
+        val KIND = Ingress::class.java;
+    }
+
+    private val ingressClient = client.adapt(ExtensionsAPIGroupClient::class.java)
+
+    override val kind = KIND
+
+    override fun getRetrieveOperation(namespace: String): () -> Watchable<Watch, Watcher<Ingress>>? {
+        return { ingressClient.ingresses().inNamespace(namespace) }
+    }
+
+}

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/IngressProvider.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/IngressProvider.kt
@@ -10,9 +10,7 @@
  ******************************************************************************/
 package org.jboss.tools.intellij.kubernetes.model.resource.kubernetes
 
-import io.fabric8.kubernetes.api.model.extensions.DoneableIngress
 import io.fabric8.kubernetes.api.model.extensions.Ingress
-import io.fabric8.kubernetes.api.model.extensions.IngressList
 import io.fabric8.kubernetes.client.ExtensionsAPIGroupClient
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.Watch
@@ -21,18 +19,17 @@ import io.fabric8.kubernetes.client.dsl.Watchable
 import org.jboss.tools.intellij.kubernetes.model.resource.NamespacedResourcesProvider
 
 class IngressProvider(client: KubernetesClient)
-    : NamespacedResourcesProvider<Ingress, KubernetesClient>(client) {
+    : NamespacedResourcesProvider<Ingress, KubernetesClient>(client),
+        IAdaptedClient<ExtensionsAPIGroupClient> by AdaptedClient(client, ExtensionsAPIGroupClient::class.java) {
 
     companion object {
         val KIND = Ingress::class.java;
     }
 
-    private val ingressClient = client.adapt(ExtensionsAPIGroupClient::class.java)
-
     override val kind = KIND
 
     override fun getRetrieveOperation(namespace: String): () -> Watchable<Watch, Watcher<Ingress>>? {
-        return { ingressClient.ingresses().inNamespace(namespace) }
+        return { adaptedClient.ingresses().inNamespace(namespace) }
     }
 
 }

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/StatefulSetsProvider.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/StatefulSetsProvider.kt
@@ -10,27 +10,26 @@
  ******************************************************************************/
 package org.jboss.tools.intellij.kubernetes.model.resource.kubernetes
 
-import io.fabric8.kubernetes.api.model.extensions.Ingress
-import io.fabric8.kubernetes.client.ExtensionsAPIGroupClient
+import io.fabric8.kubernetes.api.model.apps.StatefulSet
+import io.fabric8.kubernetes.client.AppsAPIGroupClient
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.Watch
 import io.fabric8.kubernetes.client.Watcher
 import io.fabric8.kubernetes.client.dsl.Watchable
 import org.jboss.tools.intellij.kubernetes.model.resource.NamespacedResourcesProvider
 
-class IngressProvider(client: KubernetesClient)
-    : NamespacedResourcesProvider<Ingress, KubernetesClient>(client) {
+class StatefulSetsProvider(client: KubernetesClient)
+    : NamespacedResourcesProvider<StatefulSet, KubernetesClient>(client),
+        IAdaptedClient<AppsAPIGroupClient> by AdaptedClient(client, AppsAPIGroupClient::class.java) {
 
     companion object {
-        val KIND = Ingress::class.java;
+        val KIND = StatefulSet::class.java;
     }
-
-    private val ingressClient = client.adapt(ExtensionsAPIGroupClient::class.java)
 
     override val kind = KIND
 
-    override fun getRetrieveOperation(namespace: String): () -> Watchable<Watch, Watcher<Ingress>>? {
-        return { ingressClient.ingresses().inNamespace(namespace) }
+    override fun getRetrieveOperation(namespace: String): () -> Watchable<Watch, Watcher<StatefulSet>>? {
+        return { adaptedClient.statefulSets().inNamespace(namespace) }
     }
 
 }

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/StorageClassesProvider.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/StorageClassesProvider.kt
@@ -19,7 +19,8 @@ import io.fabric8.kubernetes.client.dsl.Watchable
 import org.jboss.tools.intellij.kubernetes.model.resource.NonNamespacedResourcesProvider
 
 class StorageClassesProvider(client: KubernetesClient)
-    : NonNamespacedResourcesProvider<StorageClass, KubernetesClient>(client) {
+    : NonNamespacedResourcesProvider<StorageClass, KubernetesClient>(client),
+        IAdaptedClient<StorageAPIGroupClient> by AdaptedClient(client, StorageAPIGroupClient::class.java) {
 
     companion object {
         val KIND = StorageClass::class.java
@@ -27,11 +28,7 @@ class StorageClassesProvider(client: KubernetesClient)
 
     override val kind = KIND
 
-    private val storageClient: StorageAPIGroupClient by lazy {
-        client.adapt(StorageAPIGroupClient::class.java)
-    }
-
     override fun getRetrieveOperation(): () -> Watchable<Watch, Watcher<StorageClass>>? {
-        return { storageClient.storageClasses() }
+        return { adaptedClient.storageClasses() }
     }
 }

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/AbstractTreeStructureContribution.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/AbstractTreeStructureContribution.kt
@@ -17,4 +17,44 @@ abstract class AbstractTreeStructureContribution(override val model: IResourceMo
     protected fun getRootElement(): Any? {
         return model.getCurrentContext()
     }
+
+    fun <T> element(initializer: ElementNode<T>.() -> Unit): ElementNode<T> {
+        return ElementNode<T>().apply(initializer)
+    }
+
+    class ElementNode<T> {
+        private var parentElementsProvider: ((element: T) -> Any?)? = null
+        private var childElementsProvider: ((element: T) -> Collection<Any>)? = null
+        private lateinit var anchorProvider: (element: Any) -> Boolean
+
+        fun anchor(provider: (element: Any) -> Boolean): ElementNode<T> {
+            this.anchorProvider = provider
+            return this
+        }
+
+        fun parentElements(provider: ((element: T) -> Any?)?): ElementNode<T> {
+            this.parentElementsProvider = provider
+            return this
+        }
+
+        fun childElements(provider: (element: T) -> Collection<Any>): ElementNode<T> {
+            this.childElementsProvider = provider
+            return this
+        }
+
+        fun isAnchor(element: Any): Boolean {
+            return anchorProvider.invoke(element)
+        }
+
+        fun getChildElements(element: Any): Collection<Any> {
+            val typedElement = element as? T ?: return emptyList()
+            return childElementsProvider?.invoke(typedElement) ?: return emptyList()
+        }
+
+        fun getParentElements(element: Any): Any? {
+            val typedElement = element as? T ?: return null
+            return parentElementsProvider?.invoke(typedElement) ?: return null
+        }
+
+    }
 }

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/KubernetesStructure.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/KubernetesStructure.kt
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.Secret
 import io.fabric8.kubernetes.api.model.Service
+import io.fabric8.kubernetes.api.model.apps.StatefulSet
 import io.fabric8.kubernetes.api.model.extensions.Ingress
 import io.fabric8.kubernetes.api.model.storage.StorageClass
 import org.jboss.tools.intellij.kubernetes.model.IResourceModel
@@ -29,6 +30,7 @@ import org.jboss.tools.intellij.kubernetes.model.ResourceException
 import org.jboss.tools.intellij.kubernetes.model.context.KubernetesContext
 import org.jboss.tools.intellij.kubernetes.model.resource.DeploymentConfigFor
 import org.jboss.tools.intellij.kubernetes.model.resource.PodForService
+import org.jboss.tools.intellij.kubernetes.model.resource.PodForStatefulSet
 import org.jboss.tools.intellij.kubernetes.model.resourceName
 import org.jboss.tools.intellij.kubernetes.model.util.getContainers
 import org.jboss.tools.intellij.kubernetes.model.util.isRunning
@@ -44,6 +46,7 @@ import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.PERS
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.PODS
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.SECRETS
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.SERVICES
+import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.STATEFULSETS
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.STORAGE
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.STORAGE_CLASSES
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.WORKLOADS
@@ -55,6 +58,7 @@ class KubernetesStructure(model: IResourceModel) : AbstractTreeStructureContribu
         val NAMESPACES = Folder("Namespaces", Namespace::class.java)
         val NODES = Folder("Nodes", Node::class.java)
         val WORKLOADS = Folder("Workloads", null)
+			val STATEFULSETS = Folder("StatefulSets", StatefulSet::class.java) //  Workloads / StatefulSets
             val PODS = Folder("Pods", Pod::class.java) //  Workloads / Pods
         val NETWORK = Folder("Network", null)
             val SERVICES = Folder("Services", Service::class.java) // Network / Services
@@ -113,6 +117,7 @@ class KubernetesStructure(model: IResourceModel) : AbstractTreeStructureContribu
 			is Node -> ResourceDescriptor(element, parent, model)
 			is Pod -> PodDescriptor(element, parent, model)
 			is DescriptorFactory<*> -> element.create(parent, model)
+			is StatefulSet,
             is Service,
             is Endpoints,
             is Ingress,
@@ -333,9 +338,31 @@ class KubernetesStructure(model: IResourceModel) : AbstractTreeStructureContribu
 				element<Any> {
 					anchor { it == WORKLOADS }
 					childElements {
-						listOf<Any>(PODS)
+						listOf<Any>(PODS,
+								STATEFULSETS)
 					}
 					parentElements { getRootElement() }
+				},
+				element<Any> {
+					anchor { it == STATEFULSETS }
+					childElements {
+						model.resources(StatefulSet::class.java)
+								.inCurrentNamespace()
+								.list()
+								.sortedBy(resourceName)
+					}
+					parentElements { WORKLOADS }
+				},
+				element<StatefulSet> {
+					anchor { it is StatefulSet }
+					childElements {
+						model.resources(Pod::class.java)
+								.inCurrentNamespace()
+								.filtered(PodForStatefulSet(it))
+								.list()
+								.sortedBy(resourceName)
+					}
+					parentElements { WORKLOADS }
 				},
 				element<Any> {
 					anchor { it == PODS }

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/OpenShiftStructure.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/OpenShiftStructure.kt
@@ -24,7 +24,6 @@ import org.jboss.tools.intellij.kubernetes.model.context.OpenShiftContext
 import org.jboss.tools.intellij.kubernetes.model.resource.DeploymentConfigFor
 import org.jboss.tools.intellij.kubernetes.model.resource.ReplicationControllerFor
 import org.jboss.tools.intellij.kubernetes.tree.TreeStructure.Folder
-import org.jboss.tools.intellij.kubernetes.tree.TreeStructure.Descriptor
 import org.jboss.tools.intellij.kubernetes.tree.TreeStructure.ResourceDescriptor
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.NODES
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.WORKLOADS

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/TreeStructure.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/TreeStructure.kt
@@ -19,10 +19,9 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.util.IconLoader
 import io.fabric8.kubernetes.api.model.HasMetadata
-import io.fabric8.kubernetes.api.model.Pod
 import org.jboss.tools.intellij.kubernetes.model.IResourceModel
 import org.jboss.tools.intellij.kubernetes.model.context.IContext
-import java.util.Optional
+import java.util.*
 import javax.swing.Icon
 
 /**
@@ -38,8 +37,8 @@ open class TreeStructure(
 
     private val contributions by lazy {
         listOf(
-            *getTreeStructureDefaults(model).toTypedArray(),
-            *getTreeStructureExtensions(model).toTypedArray()
+                *getTreeStructureDefaults(model).toTypedArray(),
+                *getTreeStructureExtensions(model).toTypedArray()
         )
     }
 
@@ -59,18 +58,18 @@ open class TreeStructure(
     private fun getChildElements(element: Any, contribution: ITreeStructureContribution): Collection<Any> {
         return try {
             contribution.getChildElements(element)
-        } catch (e:  java.lang.Exception) {
+        } catch (e: java.lang.Exception) {
             logger<TreeStructure>().warn(e)
             listOf(e)
         }
     }
 
     override fun getParentElement(element: Any): Any? {
-            val parent: Optional<Any?> = getValidContributions().stream()
-                    .map { getParentElement(element, it) }
-                    .filter { it != null }
-                    .findAny()
-            return parent.orElse(rootElement)
+        val parent: Optional<Any?> = getValidContributions().stream()
+                .map { getParentElement(element, it) }
+                .filter { it != null }
+                .findAny()
+        return parent.orElse(rootElement)
     }
 
     private fun getParentElement(element: Any, contribution: ITreeStructureContribution): Any? {
@@ -94,17 +93,17 @@ open class TreeStructure(
         if (descriptor != null) {
             return descriptor
         }
-        return when(element) {
-                is IContext -> ContextDescriptor(element, parent, model = model)
-                is Exception -> ErrorDescriptor(element, parent, model = model)
-                is Folder -> FolderDescriptor(element, parent, model = model)
-                else -> Descriptor(element, parent, model = model)
-            }
+        return when (element) {
+            is IContext -> ContextDescriptor(element, parent, model = model)
+            is Exception -> ErrorDescriptor(element, parent, model = model)
+            is Folder -> FolderDescriptor(element, parent, model = model)
+            else -> Descriptor(element, parent, model = model)
+        }
     }
 
     private fun getValidContributions(): Collection<ITreeStructureContribution> {
         return contributions
-            .filter { it.canContribute() }
+                .filter { it.canContribute() }
     }
 
     private fun getTreeStructureExtensions(model: IResourceModel): List<ITreeStructureContribution> {
@@ -124,7 +123,7 @@ open class TreeStructure(
 
     override fun isToBuildChildrenInBackground(element: Any) = true
 
-    open class ContextDescriptor<C: IContext>(
+    open class ContextDescriptor<C : IContext>(
             context: C,
             parent: NodeDescriptor<*>? = null,
             model: IResourceModel)
@@ -194,10 +193,10 @@ open class TreeStructure(
         }
     }
 
-    open class ResourceDescriptor<T: HasMetadata>(
+    open class ResourceDescriptor<T : HasMetadata>(
             element: T,
             parent: NodeDescriptor<*>?,
-            model: IResourceModel): Descriptor<T>(element, parent, model) {
+            model: IResourceModel) : Descriptor<T>(element, parent, model) {
 
         override fun getLabel(element: T): String {
             return element.metadata.name
@@ -246,8 +245,9 @@ open class TreeStructure(
 
     data class Folder(val label: String, val kind: Class<out HasMetadata>?)
 
-    abstract class DescriptorFactory<R: HasMetadata>(protected val resource: R) {
+    abstract class DescriptorFactory<R : HasMetadata>(protected val resource: R) {
         abstract fun create(parent: NodeDescriptor<*>?, model: IResourceModel): NodeDescriptor<R>?
     }
 }
+
 


### PR DESCRIPTION
fixes #68
depends on #73 which has to be merged first

Here's how stateful sets are displayed in vscode:
![image](https://user-images.githubusercontent.com/25126/86009882-ff198500-ba1a-11ea-843c-2362aab0be65.png)

and here's how this PR is displaying them:
![image](https://user-images.githubusercontent.com/25126/86009795-ead58800-ba1a-11ea-85a5-baeb7d344b6b.png)

here's a yaml to create a stateful set:
```
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: mehdb
spec:
  selector:
    matchLabels:
      app: mehdb
  serviceName: "mehdb"
  replicas: 2
  template:
    metadata:
      labels:
        app: mehdb
    spec:
      containers:
      - name: shard
        image: quay.io/mhausenblas/mehdb:0.6
        ports:
        - containerPort: 9876
        env:
        - name: MEHDB_DATADIR
          value: "/mehdbdata"
        livenessProbe:
          initialDelaySeconds: 2
          periodSeconds: 10
          httpGet:
            path: /status
            port: 9876
        readinessProbe:
          initialDelaySeconds: 15
          periodSeconds: 30
          httpGet:
            path: /status?level=full
            port: 9876
        volumeMounts:
        - name: data
          mountPath: /mehdbdata
  volumeClaimTemplates:
  - metadata:
      name: data
    spec:
      accessModes: [ "ReadWriteOnce" ]
      resources:
        requests:
          storage: 1Gi
---
apiVersion: v1
kind: Service
metadata:
  name: mehdb
  labels:
    app: mehdb
spec:
  ports:
  - port: 9876
  clusterIP: None
  selector:
    app: mehdb

```