### PR TITLE
Show 'DaemonSets' (#69)

### DIFF
--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/KubernetesContext.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/KubernetesContext.kt
@@ -21,6 +21,7 @@ import org.jboss.tools.intellij.kubernetes.model.context.IActiveContext.*
 import org.jboss.tools.intellij.kubernetes.model.resource.IResourcesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.AllPodsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.ConfigMapsProvider
+import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.DaemonSetsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.EndpointsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.IngressProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.NamespacesProvider
@@ -44,6 +45,7 @@ open class KubernetesContext(
 				NamespacesProvider(client),
 				NodesProvider(client),
 				AllPodsProvider(client),
+				DaemonSetsProvider(client),
 				NamespacedPodsProvider(client),
 				ServicesProvider(client),
 				EndpointsProvider(client),

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/OpenShiftContext.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/context/OpenShiftContext.kt
@@ -19,6 +19,7 @@ import org.jboss.tools.intellij.kubernetes.model.context.IActiveContext.*
 import org.jboss.tools.intellij.kubernetes.model.resource.IResourcesProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.AllPodsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.ConfigMapsProvider
+import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.DaemonSetsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.EndpointsProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.IngressProvider
 import org.jboss.tools.intellij.kubernetes.model.resource.kubernetes.NamespacesProvider
@@ -46,6 +47,7 @@ open class OpenShiftContext(
 				NamespacesProvider(client),
 				NodesProvider(client),
 				AllPodsProvider(client),
+				DaemonSetsProvider(client),
 				NamespacedPodsProvider(client),
 				ProjectsProvider(client),
 				ImageStreamsProvider(client),

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/Filters.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/Filters.kt
@@ -10,9 +10,11 @@
  ******************************************************************************/
 package org.jboss.tools.intellij.kubernetes.model.resource
 
+import io.fabric8.kubernetes.api.model.HasMetadata
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.Service
+import io.fabric8.kubernetes.api.model.apps.DaemonSet
 import io.fabric8.openshift.api.model.DeploymentConfig
 import java.util.function.Predicate
 
@@ -40,5 +42,12 @@ class PodForService(private val service: Service) : Predicate<Pod> {
 
 	override fun test(pod: Pod): Boolean {
 		return service.spec.selector.all { pod.metadata.labels.entries.contains(it) }
+	}
+}
+
+class PodForDaemonSet(private val resource: DaemonSet) : Predicate<Pod> {
+
+	override fun test(pod: Pod): Boolean {
+		return resource.spec.selector.matchLabels.all { pod.metadata.labels.entries.contains(it) }
 	}
 }

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/AdaptedClient.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/AdaptedClient.kt
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.kubernetes.model.resource.kubernetes
+
+import io.fabric8.kubernetes.client.Client
+import io.fabric8.kubernetes.client.KubernetesClient
+
+interface IAdaptedClient<C: Client> {
+    val adaptedClient: C
+}
+
+class AdaptedClient<C: Client>(client: KubernetesClient, adapter: Class<C>): IAdaptedClient<C> {
+    override val adaptedClient: C = client.adapt(adapter)
+}

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/DaemonSetsProvider.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/DaemonSetsProvider.kt
@@ -10,27 +10,26 @@
  ******************************************************************************/
 package org.jboss.tools.intellij.kubernetes.model.resource.kubernetes
 
-import io.fabric8.kubernetes.api.model.extensions.Ingress
-import io.fabric8.kubernetes.client.ExtensionsAPIGroupClient
+import io.fabric8.kubernetes.api.model.apps.DaemonSet
+import io.fabric8.kubernetes.client.AppsAPIGroupClient
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.Watch
 import io.fabric8.kubernetes.client.Watcher
 import io.fabric8.kubernetes.client.dsl.Watchable
 import org.jboss.tools.intellij.kubernetes.model.resource.NamespacedResourcesProvider
 
-class IngressProvider(client: KubernetesClient)
-    : NamespacedResourcesProvider<Ingress, KubernetesClient>(client) {
+class DaemonSetsProvider(client: KubernetesClient)
+	: NamespacedResourcesProvider<DaemonSet, KubernetesClient>(client),
+		IAdaptedClient<AppsAPIGroupClient> by AdaptedClient(client, AppsAPIGroupClient::class.java) {
 
-    companion object {
-        val KIND = Ingress::class.java;
-    }
+	companion object {
+		val KIND = DaemonSet::class.java;
+	}
 
-    private val ingressClient = client.adapt(ExtensionsAPIGroupClient::class.java)
+	override val kind = KIND
 
-    override val kind = KIND
-
-    override fun getRetrieveOperation(namespace: String): () -> Watchable<Watch, Watcher<Ingress>>? {
-        return { ingressClient.ingresses().inNamespace(namespace) }
-    }
+	override fun getRetrieveOperation(namespace: String): () -> Watchable<Watch, Watcher<DaemonSet>>? {
+		return { adaptedClient.daemonSets().inNamespace(namespace) }
+	}
 
 }

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/DaemonSetsProvider.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/DaemonSetsProvider.kt
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.kubernetes.model.resource.kubernetes
+
+import io.fabric8.kubernetes.api.model.extensions.Ingress
+import io.fabric8.kubernetes.client.ExtensionsAPIGroupClient
+import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.Watch
+import io.fabric8.kubernetes.client.Watcher
+import io.fabric8.kubernetes.client.dsl.Watchable
+import org.jboss.tools.intellij.kubernetes.model.resource.NamespacedResourcesProvider
+
+class IngressProvider(client: KubernetesClient)
+    : NamespacedResourcesProvider<Ingress, KubernetesClient>(client) {
+
+    companion object {
+        val KIND = Ingress::class.java;
+    }
+
+    private val ingressClient = client.adapt(ExtensionsAPIGroupClient::class.java)
+
+    override val kind = KIND
+
+    override fun getRetrieveOperation(namespace: String): () -> Watchable<Watch, Watcher<Ingress>>? {
+        return { ingressClient.ingresses().inNamespace(namespace) }
+    }
+
+}

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/IngressProvider.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/model/resource/kubernetes/IngressProvider.kt
@@ -10,9 +10,7 @@
  ******************************************************************************/
 package org.jboss.tools.intellij.kubernetes.model.resource.kubernetes
 
-import io.fabric8.kubernetes.api.model.extensions.DoneableIngress
 import io.fabric8.kubernetes.api.model.extensions.Ingress
-import io.fabric8.kubernetes.api.model.extensions.IngressList
 import io.fabric8.kubernetes.client.ExtensionsAPIGroupClient
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.Watch

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/AbstractTreeStructureContribution.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/AbstractTreeStructureContribution.kt
@@ -17,4 +17,44 @@ abstract class AbstractTreeStructureContribution(override val model: IResourceMo
     protected fun getRootElement(): Any? {
         return model.getCurrentContext()
     }
+
+    fun <T> element(initializer: ElementNode<T>.() -> Unit): ElementNode<T> {
+        return ElementNode<T>().apply(initializer)
+    }
+
+    class ElementNode<T> {
+        private var parentElementsProvider: ((element: T) -> Any?)? = null
+        private var childElementsProvider: ((element: T) -> Collection<Any>)? = null
+        private lateinit var anchorProvider: (element: Any) -> Boolean
+
+        fun anchor(provider: (element: Any) -> Boolean): ElementNode<T> {
+            this.anchorProvider = provider
+            return this
+        }
+
+        fun parentElements(provider: ((element: T) -> Any?)?): ElementNode<T> {
+            this.parentElementsProvider = provider
+            return this
+        }
+
+        fun childElements(provider: (element: T) -> Collection<Any>): ElementNode<T> {
+            this.childElementsProvider = provider
+            return this
+        }
+
+        fun isAnchor(element: Any): Boolean {
+            return anchorProvider.invoke(element)
+        }
+
+        fun getChildElements(element: Any): Collection<Any> {
+            val typedElement = element as? T ?: return emptyList()
+            return childElementsProvider?.invoke(typedElement) ?: return emptyList()
+        }
+
+        fun getParentElements(element: Any): Any? {
+            val typedElement = element as? T ?: return null
+            return parentElementsProvider?.invoke(typedElement) ?: return null
+        }
+
+    }
 }

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/OpenShiftStructure.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/OpenShiftStructure.kt
@@ -24,7 +24,6 @@ import org.jboss.tools.intellij.kubernetes.model.context.OpenShiftContext
 import org.jboss.tools.intellij.kubernetes.model.resource.DeploymentConfigFor
 import org.jboss.tools.intellij.kubernetes.model.resource.ReplicationControllerFor
 import org.jboss.tools.intellij.kubernetes.tree.TreeStructure.Folder
-import org.jboss.tools.intellij.kubernetes.tree.TreeStructure.Descriptor
 import org.jboss.tools.intellij.kubernetes.tree.TreeStructure.ResourceDescriptor
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.NODES
 import org.jboss.tools.intellij.kubernetes.tree.KubernetesStructure.Folders.WORKLOADS

--- a/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/TreeStructure.kt
+++ b/src/main/kotlin/org/jboss/tools/intellij/kubernetes/tree/TreeStructure.kt
@@ -19,10 +19,9 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.util.IconLoader
 import io.fabric8.kubernetes.api.model.HasMetadata
-import io.fabric8.kubernetes.api.model.Pod
 import org.jboss.tools.intellij.kubernetes.model.IResourceModel
 import org.jboss.tools.intellij.kubernetes.model.context.IContext
-import java.util.Optional
+import java.util.*
 import javax.swing.Icon
 
 /**
@@ -38,8 +37,8 @@ open class TreeStructure(
 
     private val contributions by lazy {
         listOf(
-            *getTreeStructureDefaults(model).toTypedArray(),
-            *getTreeStructureExtensions(model).toTypedArray()
+                *getTreeStructureDefaults(model).toTypedArray(),
+                *getTreeStructureExtensions(model).toTypedArray()
         )
     }
 
@@ -59,18 +58,18 @@ open class TreeStructure(
     private fun getChildElements(element: Any, contribution: ITreeStructureContribution): Collection<Any> {
         return try {
             contribution.getChildElements(element)
-        } catch (e:  java.lang.Exception) {
+        } catch (e: java.lang.Exception) {
             logger<TreeStructure>().warn(e)
             listOf(e)
         }
     }
 
     override fun getParentElement(element: Any): Any? {
-            val parent: Optional<Any?> = getValidContributions().stream()
-                    .map { getParentElement(element, it) }
-                    .filter { it != null }
-                    .findAny()
-            return parent.orElse(rootElement)
+        val parent: Optional<Any?> = getValidContributions().stream()
+                .map { getParentElement(element, it) }
+                .filter { it != null }
+                .findAny()
+        return parent.orElse(rootElement)
     }
 
     private fun getParentElement(element: Any, contribution: ITreeStructureContribution): Any? {
@@ -94,17 +93,17 @@ open class TreeStructure(
         if (descriptor != null) {
             return descriptor
         }
-        return when(element) {
-                is IContext -> ContextDescriptor(element, parent, model = model)
-                is Exception -> ErrorDescriptor(element, parent, model = model)
-                is Folder -> FolderDescriptor(element, parent, model = model)
-                else -> Descriptor(element, parent, model = model)
-            }
+        return when (element) {
+            is IContext -> ContextDescriptor(element, parent, model = model)
+            is Exception -> ErrorDescriptor(element, parent, model = model)
+            is Folder -> FolderDescriptor(element, parent, model = model)
+            else -> Descriptor(element, parent, model = model)
+        }
     }
 
     private fun getValidContributions(): Collection<ITreeStructureContribution> {
         return contributions
-            .filter { it.canContribute() }
+                .filter { it.canContribute() }
     }
 
     private fun getTreeStructureExtensions(model: IResourceModel): List<ITreeStructureContribution> {
@@ -124,7 +123,7 @@ open class TreeStructure(
 
     override fun isToBuildChildrenInBackground(element: Any) = true
 
-    open class ContextDescriptor<C: IContext>(
+    open class ContextDescriptor<C : IContext>(
             context: C,
             parent: NodeDescriptor<*>? = null,
             model: IResourceModel)
@@ -194,10 +193,10 @@ open class TreeStructure(
         }
     }
 
-    open class ResourceDescriptor<T: HasMetadata>(
+    open class ResourceDescriptor<T : HasMetadata>(
             element: T,
             parent: NodeDescriptor<*>?,
-            model: IResourceModel): Descriptor<T>(element, parent, model) {
+            model: IResourceModel) : Descriptor<T>(element, parent, model) {
 
         override fun getLabel(element: T): String {
             return element.metadata.name
@@ -246,8 +245,9 @@ open class TreeStructure(
 
     data class Folder(val label: String, val kind: Class<out HasMetadata>?)
 
-    abstract class DescriptorFactory<R: HasMetadata>(protected val resource: R) {
+    abstract class DescriptorFactory<R : HasMetadata>(protected val resource: R) {
         abstract fun create(parent: NodeDescriptor<*>?, model: IResourceModel): NodeDescriptor<R>?
     }
 }
+
 


### PR DESCRIPTION
fixes #69 
depends on #73 which has to be merged first

here's how vscode is displaying them:
![image](https://user-images.githubusercontent.com/25126/86019337-c089c780-ba26-11ea-9546-635925f48fe9.png)

here's how this PR is displaying them:
![image](https://user-images.githubusercontent.com/25126/86019433-e3b47700-ba26-11ea-8d65-918f752b055d.png)

here's a yaml to create a daemon set:
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: fluentd-elasticsearch
  namespace: default
  labels:
    k8s-app: fluentd-logging
spec:
  selector:
    matchLabels:
      name: fluentd-elasticsearch
  template:
    metadata:
      labels:
        name: fluentd-elasticsearch
    spec:
      tolerations:
      # this toleration is to have the daemonset runnable on master nodes
      # remove it if your masters can't run pods
      - key: node-role.kubernetes.io/master
        effect: NoSchedule
      containers:
      - name: fluentd-elasticsearch
        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
        resources:
          limits:
            memory: 200Mi
          requests:
            cpu: 100m
            memory: 200Mi
        volumeMounts:
        - name: varlog
          mountPath: /var/log
        - name: varlibdockercontainers
          mountPath: /var/lib/docker/containers
          readOnly: true
      terminationGracePeriodSeconds: 30
      volumes:
      - name: varlog
        hostPath:
          path: /var/log
      - name: varlibdockercontainers
        hostPath:
          path: /var/lib/docker/containers
```