### PR TITLE
Notify what resources have been deleted (#148)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/actions/DeleteResourceAction.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/actions/DeleteResourceAction.kt
@@ -39,6 +39,7 @@ class DeleteResourceAction: StructureTreeAction() {
             Progressive {
                 try {
                     model.delete(toDelete)
+                    Notification().info("Resources Deleted", toMessage(toDelete, 30))
                 } catch (e: MultiResourceException) {
                     val resources = e.causes.flatMap { it.resources }
                     Notification().error("Could not delete resource(s)", toMessage(resources, 30))

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/Notification.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/Notification.kt
@@ -28,4 +28,10 @@ class Notification {
 		NOTIFICATION_GROUP.createNotification(title, content, NotificationType.ERROR, null)
 			.notify(null)
 	}
+
+	fun info(title: String, content: String) {
+		NOTIFICATION_GROUP.createNotification(title, content, NotificationType.INFORMATION, null)
+			.notify(null)
+	}
+
 }


### PR DESCRIPTION
fixes #148

Introduces a notification that informs about the resources that have been successfully deleted:
![image](https://user-images.githubusercontent.com/25126/103000087-9a069e00-452a-11eb-8f63-82fd962e192a.png)

The shortcoming here is of course like in #147: if deletion one or more resources could not be deleted, then all resources are reported as having failed, no notification of deleted resources happens. The expected result is that failed and succeeded delete operations should be notified separately. I'll fix that in #147 