### PR TITLE
suppressing unchecked cast warnings

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/ResourceWatch.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/ResourceWatch.kt
@@ -141,6 +141,7 @@ open class ResourceWatch(
             return if (watchable == null) {
               return null
             } else {
+                @Suppress("UNCHECKED_CAST")
                 (watchable as Watchable<Watcher<in R>>).watch(ResourceWatcher(addOperation, removeOperation, replaceOperation))
             }
         }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt
@@ -63,6 +63,7 @@ abstract class ActiveContext<N : HasMetadata, C : KubernetesClient>(
         getAllResourceProviders(INonNamespacedResourcesProvider::class.java)
     }
     protected open val namespacedProviders: MutableMap<ResourceKind<out HasMetadata>, INamespacedResourcesProvider<out HasMetadata, C>> by lazy {
+        @Suppress("UNCHECKED_CAST")
         val providers = getAllResourceProviders(INamespacedResourcesProvider::class.java)
                 as MutableMap<ResourceKind<out HasMetadata>, INamespacedResourcesProvider<out HasMetadata, C>>
         setCurrentNamespace(providers.values)
@@ -93,6 +94,7 @@ abstract class ActiveContext<N : HasMetadata, C : KubernetesClient>(
 
     private fun setCurrentNamespace(providers: Collection<INamespacedResourcesProvider<*, *>>) {
         try {
+            @Suppress("UNCHECKED_CAST")
             val namespacesProvider: INonNamespacedResourcesProvider<N, C> = nonNamespacedProviders[getNamespacesKind()]
                     as INonNamespacedResourcesProvider<N, C>
             val namespace = getCurrentNamespace(namespacesProvider.allResources)
@@ -151,9 +153,11 @@ abstract class ActiveContext<N : HasMetadata, C : KubernetesClient>(
     ) {
         when (resourcesIn) {
             CURRENT_NAMESPACE ->
+                @Suppress("UNCHECKED_CAST")
                 namespacedProviders[kind] = provider as INamespacedResourcesProvider<out HasMetadata, C>
             ANY_NAMESPACE,
             NO_NAMESPACE ->
+                @Suppress("UNCHECKED_CAST")
                 nonNamespacedProviders[kind] = provider as INonNamespacedResourcesProvider<out HasMetadata, C>
         }
     }
@@ -161,10 +165,12 @@ abstract class ActiveContext<N : HasMetadata, C : KubernetesClient>(
     private fun <R: HasMetadata> getProvider(kind: ResourceKind<R>, resourcesIn: ResourcesIn): IResourcesProvider<R>? {
         return when(resourcesIn) {
             CURRENT_NAMESPACE -> {
+                @Suppress("UNCHECKED_CAST")
                 namespacedProviders[kind] as IResourcesProvider<R>?
             }
             ANY_NAMESPACE,
             NO_NAMESPACE ->
+                @Suppress("UNCHECKED_CAST")
                 nonNamespacedProviders[kind] as IResourcesProvider<R>?
         }
     }
@@ -256,6 +262,8 @@ abstract class ActiveContext<N : HasMetadata, C : KubernetesClient>(
         val watchables = namespacedProviders.entries.toList()
             .filter { kinds.contains(it.key) }
             .map { Pair(it.value.kind, it.value.getWatchable()) }
+
+        @Suppress("UNCHECKED_CAST")
         watch.watchAll(watchables
                 as Collection<Pair<ResourceKind<out HasMetadata>, Supplier<Watchable<Watcher<in HasMetadata>>?>>>)
     }
@@ -265,6 +273,7 @@ abstract class ActiveContext<N : HasMetadata, C : KubernetesClient>(
             return
         }
 
+        @Suppress("UNCHECKED_CAST")
         watch.watch(provider.kind, provider.getWatchable()
                 as Supplier<Watchable<Watcher<in HasMetadata>>?>)
     }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/AbstractResourcesProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/AbstractResourcesProvider.kt
@@ -32,6 +32,7 @@ abstract class AbstractResourcesProvider<R : HasMetadata> : IResourcesProvider<R
         logger<AbstractResourcesProvider<*>>().debug("Adding resource ${resource.metadata.name}.")
         // don't add resource if different instance of same resource is already contained
         synchronized(_allResources) {
+            @Suppress("UNCHECKED_CAST")
             return when (val existing = _allResources.find { resource.sameResource(it) }) {
                 null -> _allResources.add(resource as R)
                 resource -> false
@@ -69,6 +70,7 @@ abstract class AbstractResourcesProvider<R : HasMetadata> : IResourcesProvider<R
         if (indexOf < 0) {
             return false
         }
+        @Suppress("UNCHECKED_CAST")
         _allResources[indexOf] = replaceBy as R
         return true
     }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/NamespacedResourcesProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/NamespacedResourcesProvider.kt
@@ -62,6 +62,7 @@ abstract class NamespacedResourcesProvider<R : HasMetadata, C: Client>(
             logger<NamespacedResourcesProvider<*, *>>().debug("Returned empty watch for $kind: no namespace set.")
             return Supplier { null }
         }
+        @Suppress("UNCHECKED_CAST")
         return getOperation(namespace!!) as Supplier<Watchable<Watcher<R>>?>
     }
 
@@ -73,6 +74,7 @@ abstract class NamespacedResourcesProvider<R : HasMetadata, C: Client>(
         if (namespace == null) {
             return false
         }
+        @Suppress("UNCHECKED_CAST")
         val toDelete = resources as? List<R> ?: return false
         return getOperation(namespace!!).get()?.delete(toDelete) ?: false
     }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/NonNamespacedResourcesProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/NonNamespacedResourcesProvider.kt
@@ -40,6 +40,7 @@ abstract class NonNamespacedResourcesProvider<R : HasMetadata, C : Client>(
     }
 
     override fun getWatchable(): Supplier<Watchable<Watcher<R>>?> {
+        @Suppress("UNCHECKED_CAST")
         return getOperation() as Supplier<Watchable<Watcher<R>>?>
     }
 
@@ -48,6 +49,7 @@ abstract class NonNamespacedResourcesProvider<R : HasMetadata, C : Client>(
     }
 
     override fun delete(resources: List<HasMetadata>): Boolean {
+        @Suppress("UNCHECKED_CAST")
         val toDelete = resources as? List<R> ?: return false
         return getOperation().get()?.delete(toDelete) ?: false
     }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/CustomResourceDefinitionsProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/CustomResourceDefinitionsProvider.kt
@@ -27,6 +27,7 @@ class CustomResourceDefinitionsProvider(client: KubernetesClient)
     override val kind = KIND
 
     override fun getOperation(): Supplier<WatchableListableDeletable<CustomResourceDefinition>> {
+        @Suppress("UNCHECKED_CAST")
         return Supplier { client.customResourceDefinitions() }
     }
 }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/GenericCustomResourceFactory.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/GenericCustomResourceFactory.kt
@@ -33,6 +33,7 @@ object GenericCustomResourceFactory {
 	const val UID = "uid"
 
 	fun createResources(resourcesList: Map<String, Any?>): List<GenericCustomResource> {
+		@Suppress("UNCHECKED_CAST")
 		val items = resourcesList[ITEMS] as? List<Map<String, Any?>> ?: return emptyList()
 		return createResources(items)
 	}
@@ -44,6 +45,7 @@ object GenericCustomResourceFactory {
 	}
 
 	private fun createResource(item: Map<String, Any?>): GenericCustomResource {
+		@Suppress("UNCHECKED_CAST")
 		return GenericCustomResource(
 			item[KIND] as? String,
 			item[API_VERSION] as? String,

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/NamespacedCustomResourcesProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/NamespacedCustomResourcesProvider.kt
@@ -47,6 +47,7 @@ class NamespacedCustomResourcesProvider(
     }
 
 	override fun delete(resources: List<HasMetadata>): Boolean {
+		@Suppress("UNCHECKED_CAST")
 		val toDelete = resources as? List<GenericCustomResource> ?: return false
 		return toDelete.stream()
 			.map { delete(it.metadata.namespace, it.metadata.name) }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/NonNamespacedCustomResourcesProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/NonNamespacedCustomResourcesProvider.kt
@@ -43,6 +43,7 @@ class NonNamespacedCustomResourcesProvider(
     }
 
     override fun delete(resources: List<HasMetadata>): Boolean {
+        @Suppress("UNCHECKED_CAST")
         val toDelete = resources as? List<GenericCustomResource> ?: return false
         return toDelete.stream()
             .map { delete(it.metadata.name) }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/util/Clients.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/util/Clients.kt
@@ -42,6 +42,7 @@ class Clients<C: Client>(private val client: C) {
     }
 
     fun <T: Client> get(type: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
         return if (type.isAssignableFrom(client::class.java)) {
             client as T
         } else {

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/AbstractTreeStructureContribution.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/AbstractTreeStructureContribution.kt
@@ -55,11 +55,13 @@ abstract class AbstractTreeStructureContribution(override val model: IResourceMo
         }
 
         fun getChildElements(element: Any): Collection<Any> {
+            @Suppress("UNCHECKED_CAST")
             val typedElement = element as? T ?: return emptyList()
             return childElementsProvider?.invoke(typedElement) ?: return emptyList()
         }
 
         fun getParentElements(element: Any): Any? {
+            @Suppress("UNCHECKED_CAST")
             val typedElement = element as? T ?: return null
             return parentElementsProvider?.invoke(typedElement)
         }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/KubernetesDescriptors.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/KubernetesDescriptors.kt
@@ -179,10 +179,10 @@ object KubernetesDescriptors {
 				parent,
 				model
 		) {
-			override fun getLabel(pod: Pod): String {
-				val total = PodStatusUtil.getContainerStatus(pod).size
-				val ready = PodStatusUtil.getContainerStatus(pod).filter { it.ready }.size
-				val state = pod.status.phase
+			override fun getLabel(element: Pod): String {
+				val total = PodStatusUtil.getContainerStatus(element).size
+				val ready = PodStatusUtil.getContainerStatus(element).filter { it.ready }.size
+				val state = element.status.phase
 				return "$state ($ready/$total)"
 			}
 		}

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/KubernetesContextTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/KubernetesContextTest.kt
@@ -192,6 +192,7 @@ class KubernetesContextTest {
 				.map { it.kind }
 		whenever(context.watch.stopWatchAll(any()))
 			.doReturn(removed)
+		@Suppress("UNCHECKED_CAST", "UNCHECKED_CAST")
 		val reWatched: Array<Pair<ResourceKind<out HasMetadata>, Supplier<Watchable<Watcher<in HasMetadata>>?>>> =
 			context.namespacedProviders.values
 				.filter { removed.contains(it.kind) }
@@ -510,6 +511,7 @@ class KubernetesContextTest {
 		// when
 		context.watch(ResourceKind.create(namespacedDefinition))
 		// then
+		@Suppress("UNCHECKED_CAST")
 		verify(context.watch, times(1)).watch(namespacedCustomResourcesProvider.kind, watchableSupplier1
 				as Supplier<Watchable<Watcher<in HasMetadata>>?>)
 	}
@@ -523,6 +525,7 @@ class KubernetesContextTest {
 		// when
 		context.watch(ResourceKind.create(clusterwideDefinition))
 		// then
+		@Suppress("UNCHECKED_CAST")
 		verify(context.watch, times(1)).watch(nonNamespacedCustomResourcesProvider.kind, watchableSupplier2
 				as Supplier<Watchable<Watcher<in HasMetadata>>?>)
 	}
@@ -965,9 +968,11 @@ class KubernetesContextTest {
 				.doReturn(kind)
 		}
 		if (resourceProvider is INamespacedResourcesProvider<*, *>) {
+			@Suppress("UNCHECKED_CAST")
 			context.namespacedProviders[kind] =
 				resourceProvider as INamespacedResourcesProvider<*, NamespacedKubernetesClient>
 		} else if (resourceProvider is INonNamespacedResourcesProvider<*, *>) {
+			@Suppress("UNCHECKED_CAST")
 			context.nonNamespacedProviders[kind] =
 				resourceProvider as INonNamespacedResourcesProvider<*, NamespacedKubernetesClient>
 		}

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/tree/TreeStructureExtensionTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/tree/TreeStructureExtensionTest.kt
@@ -127,6 +127,7 @@ class TreeStructureExtensionTest {
 		return mock {
 			on { canContribute() } doReturn canContribute
 			on { getChildElements(any()) } doAnswer {
+				@Suppress("UNCHECKED_CAST")
 				when (children) {
 					// throw exception
 					is Exception -> throw children


### PR DESCRIPTION
suppresses unchecked cast warning that the build currently reports:
```
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/ResourceWatch.kt: (144, 28): Unchecked cast: Watchable<out Watcher<in R>>? to Watchable<Watcher<in R>>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt: (67, 17): Unchecked cast: MutableMap<ResourceKind<out HasMetadata>, INamespacedResourcesProvider<*, *>> to MutableMap<ResourceKind<out HasMetadata>, INamespacedResourcesProvider<out HasMetadata, C>>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt: (97, 21): Unchecked cast: INonNamespacedResourcesProvider<*, *>? to INonNamespacedResourcesProvider<N, C>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt: (154, 54): Unchecked cast: IResourcesProvider<out HasMetadata> to INamespacedResourcesProvider<out HasMetadata, C>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt: (157, 57): Unchecked cast: IResourcesProvider<out HasMetadata> to INonNamespacedResourcesProvider<out HasMetadata, C>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt: (164, 43): Unchecked cast: INamespacedResourcesProvider<out HasMetadata, C>? to IResourcesProvider<R>?
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt: (168, 46): Unchecked cast: INonNamespacedResourcesProvider<*, *>? to IResourcesProvider<R>?
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt: (260, 17): Unchecked cast: List<Pair<ResourceKind<out HasMetadata>, Supplier<out Watchable<out Watcher<out HasMetadata>>?>>> to Collection<Pair<ResourceKind<out HasMetadata>, Supplier<Watchable<Watcher<in HasMetadata>>?>>>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt: (269, 17): Unchecked cast: Supplier<out Watchable<out Watcher<out HasMetadata>>?> to Supplier<Watchable<Watcher<in HasMetadata>>?>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/AbstractResourcesProvider.kt: (36, 52): Unchecked cast: HasMetadata to R
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/AbstractResourcesProvider.kt: (72, 44): Unchecked cast: HasMetadata to R
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/NamespacedResourcesProvider.kt: (65, 42): Unchecked cast: Supplier<WatchableListableDeletable<R> /* = FilterWatchListMultiDeletable<R, out KubernetesResourceList<R>>? */> to Supplier<Watchable<Watcher<R>>?>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/NamespacedResourcesProvider.kt: (76, 34): Unchecked cast: List<HasMetadata> to List<R>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/NonNamespacedResourcesProvider.kt: (43, 31): Unchecked cast: Supplier<WatchableListableDeletable<R> /* = FilterWatchListMultiDeletable<R, out KubernetesResourceList<R>>? */> to Supplier<Watchable<Watcher<R>>?>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/NonNamespacedResourcesProvider.kt: (51, 34): Unchecked cast: List<HasMetadata> to List<R>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/GenericCustomResourceFactory.kt: (36, 36): Unchecked cast: Any? to List<Map<String, Any?>>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/GenericCustomResourceFactory.kt: (50, 40): Unchecked cast: Any? to Map<String, Any?>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/GenericCustomResourceFactory.kt: (51, 41): Unchecked cast: Any? to Map<String, Any?>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/NamespacedCustomResourcesProvider.kt: (50, 28): Unchecked cast: List<HasMetadata> to List<GenericCustomResource>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/NonNamespacedCustomResourcesProvider.kt: (46, 34): Unchecked cast: List<HasMetadata> to List<GenericCustomResource>
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/util/Clients.kt: (46, 20): Unchecked cast: C to T
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/util/Clients.kt: (48, 66): Unchecked cast: Client to T
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/AbstractTreeStructureContribution.kt: (58, 40): Unchecked cast: Any to T
w: /Users/andredietisheim/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/AbstractTreeStructureContribution.kt: (63, 40): Unchecked cast: Any to T
```