### PR TITLE
use intellij-common 1.0.0 (was: 0.0.2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     implementation(
-            "com.redhat.devtools.intellij:intellij-common:0.0.2",
+            "com.redhat.devtools.intellij:intellij-common:1.0.0",
             "org.jetbrains.kotlin:kotlin-gradle-plugin",
             "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
             "io.fabric8:kubernetes-client:5.0.2",


### PR DESCRIPTION
preparing the release for intellij-kubernetes: use latest intellij-common