### PR TITLE
removed unnecessary dependencies in build.gradle (#185)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,6 @@ dependencies {
     integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     implementation(
             "com.redhat.devtools.intellij:intellij-common:1.0.0",
-            "org.jetbrains.kotlin:kotlin-gradle-plugin",
-            "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
             "io.fabric8:kubernetes-client:5.0.2",
             "io.fabric8:kubernetes-model:5.0.2",
             "io.fabric8:kubernetes-model-common:5.0.2",


### PR DESCRIPTION
fixes #185 

this PR removes the following dependencies that the issue complains about:
```
gradle-download-task-4.0.2.jar
kotlin-android-extensions-1.3.72.jar
kotlin-annotation-processing-gradle-1.3.72.jar
kotlin-build-common-1.3.72.jar
kotlin-compiler-embeddable-1.3.72.jar
kotlin-compiler-runner-1.3.72.jar
```
Here's the complete list of dependencies that are included with this PR:
```
automaton-1.11-8.jar
commons-exec-1.3.jar
commons-lang3-3.10.jar
generex-1.0.2.jar
intellij-common-1.0.0.jar
intellij-kubernetes-0.1.7-SNAPSHOT.jar
jackson-annotations-2.11.2.jar
jackson-core-2.11.2.jar
jackson-databind-2.11.2.jar
jackson-dataformat-yaml-2.11.2.jar
jackson-datatype-jsr310-2.11.2.jar
kubernetes-client-5.0.2.jar
kubernetes-model-5.0.2.jar
kubernetes-model-admissionregistration-5.0.2.jar
kubernetes-model-apiextensions-5.0.2.jar
kubernetes-model-apps-5.0.2.jar
kubernetes-model-autoscaling-5.0.2.jar
kubernetes-model-batch-5.0.2.jar
kubernetes-model-certificates-5.0.2.jar
kubernetes-model-common-5.0.2.jar
kubernetes-model-coordination-5.0.2.jar
kubernetes-model-core-5.0.2.jar
kubernetes-model-discovery-5.0.2.jar
kubernetes-model-events-5.0.2.jar
kubernetes-model-extensions-5.0.2.jar
kubernetes-model-metrics-5.0.2.jar
kubernetes-model-networking-5.0.2.jar
kubernetes-model-node-5.0.2.jar
kubernetes-model-policy-5.0.2.jar
kubernetes-model-rbac-5.0.2.jar
kubernetes-model-scheduling-5.0.2.jar
kubernetes-model-settings-5.0.2.jar
kubernetes-model-storageclass-5.0.2.jar
logging-interceptor-3.12.12.jar
okhttp-3.12.12.jar
okio-1.15.0.jar
openshift-client-5.0.2.jar
openshift-model-5.0.2.jar
openshift-model-console-5.0.2.jar
openshift-model-monitoring-5.0.2.jar
openshift-model-operator-5.0.2.jar
openshift-model-operatorhub-5.0.2.jar
snakeyaml-1.26.jar
zjsonpatch-0.3.0.jar
```