### PR TITLE
chore: set Jenkins to use jdk11 (#257)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,9 @@
 
 node('rhel7'){
 	def recipientList = 'jbosstools-builds@lists.jboss.org'
-	
+	def javaHome = tool 'openjdk-11'
+	env.JAVA_HOME = "${javaHome}"
+
 	try {
 		stage('Checkout repo') {
 			deleteDir()


### PR DESCRIPTION
fixes #257 