### PR TITLE
Prevent from failure of addding special characters on following pod log

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/logs/TerminalOutputStream.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/logs/TerminalOutputStream.kt
@@ -13,7 +13,7 @@ package com.redhat.devtools.intellij.kubernetes.logs
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.terminal.TerminalExecutionConsole
 import java.io.OutputStream
-import java.util.Queue
+import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 
 class TerminalOutputStream(private val terminal: TerminalExecutionConsole) : OutputStream() {
@@ -42,8 +42,16 @@ class TerminalOutputStream(private val terminal: TerminalExecutionConsole) : Out
 
     private fun flushToTerminal(buffer: Queue<Int>) {
         val builder = buffer.stream()
-            .collect(::StringBuilder, StringBuilder::appendCodePoint, StringBuilder::append)
+            .collect(::StringBuilder, this::appendCodePoint, StringBuilder::append)
         buffer.clear()
         terminal.print(builder.toString(), ConsoleViewContentType.SYSTEM_OUTPUT)
+    }
+
+    private fun appendCodePoint(builder: java.lang.StringBuilder, codePoint: Int): java.lang.StringBuilder {
+        try {
+            builder.appendCodePoint(codePoint)
+        } catch (_: Throwable) {
+        }
+        return builder
     }
 }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/logs/TerminalOutputStream.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/logs/TerminalOutputStream.kt
@@ -13,7 +13,7 @@ package com.redhat.devtools.intellij.kubernetes.logs
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.terminal.TerminalExecutionConsole
 import java.io.OutputStream
-import java.util.*
+import java.util.Queue
 import java.util.concurrent.LinkedBlockingQueue
 
 class TerminalOutputStream(private val terminal: TerminalExecutionConsole) : OutputStream() {


### PR DESCRIPTION
On special log characters, the plugin will fail with following exception:

```text
Error while pumping stream.

java.lang.IllegalArgumentException: Not a valid Unicode code point: 0xFFFFFFE7
	at java.base/java.lang.Character.toChars(Character.java:9218)
	at java.base/java.lang.AbstractStringBuilder.appendCodePoint(AbstractStringBuilder.java:949)
	at java.base/java.lang.StringBuilder.appendCodePoint(StringBuilder.java:280)
	at com.redhat.devtools.intellij.kubernetes.logs.TerminalOutputStream$flushToTerminal$builder$2.invoke(TerminalOutputStream.kt:45)
	at com.redhat.devtools.intellij.kubernetes.logs.TerminalOutputStream$flushToTerminal$builder$2.invoke(TerminalOutputStream.kt:19)
	at com.redhat.devtools.intellij.kubernetes.logs.TerminalOutputStream$sam$java_util_function_BiConsumer$0.accept(TerminalOutputStream.kt)
	at java.base/java.util.stream.ReduceOps$4ReducingSink.accept(ReduceOps.java:220)
	at java.base/java.util.concurrent.LinkedBlockingQueue.forEachFrom(LinkedBlockingQueue.java:1012)
	at java.base/java.util.concurrent.LinkedBlockingQueue$LBQSpliterator.forEachRemaining(LinkedBlockingQueue.java:945)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:693)
	at com.redhat.devtools.intellij.kubernetes.logs.TerminalOutputStream.flushToTerminal(TerminalOutputStream.kt:45)
	at com.redhat.devtools.intellij.kubernetes.logs.TerminalOutputStream.write(TerminalOutputStream.kt:36)
	at java.base/java.io.OutputStream.write(OutputStream.java:162)
	at io.fabric8.kubernetes.client.utils.InputStreamPumper.transferTo(InputStreamPumper.java:77)
	at io.fabric8.kubernetes.client.utils.InputStreamPumper.lambda$pump$0(InputStreamPumper.java:89)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```