### PR TITLE
display pods for job (#478)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/Filters.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/Filters.kt
@@ -10,16 +10,17 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.kubernetes.model.resource
 
-import io.fabric8.kubernetes.api.model.HasMetadata
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.api.model.apps.DaemonSet
 import io.fabric8.kubernetes.api.model.apps.Deployment
 import io.fabric8.kubernetes.api.model.apps.StatefulSet
+import io.fabric8.kubernetes.api.model.batch.v1.Job
 import io.fabric8.openshift.api.model.Build
 import io.fabric8.openshift.api.model.BuildConfig
 import io.fabric8.openshift.api.model.DeploymentConfig
+import io.fabric8.openshift.client.dsl.internal.build.BuildOperationsImpl
 import java.util.function.Predicate
 
 class ReplicationControllerFor(private val dc: DeploymentConfig) : Predicate<ReplicationController> {
@@ -55,7 +56,7 @@ class BuildConfigFor(build: Build) : Predicate<BuildConfig> {
 
 	private val bcKey = "openshift.io/build-config.name"
 	private val bcName: String? = build.metadata.annotations[bcKey]
-			?: build.metadata.labels[bcKey]
+		?: build.metadata.labels[bcKey]
 
 	override fun test(bc: BuildConfig): Boolean {
 		return bcName != null
@@ -64,24 +65,38 @@ class BuildConfigFor(build: Build) : Predicate<BuildConfig> {
 }
 
 class PodForService(service: Service)
-	: PodForResource<Pod>(service.spec.selector)
+	: PodForResource(service.spec.selector)
 
 class PodForDeployment(deployment: Deployment)
-	: PodForResource<Pod>(deployment.spec.selector.matchLabels)
+	: PodForResource(deployment.spec.selector.matchLabels)
 
 class PodForStatefulSet(statefulSet: StatefulSet)
-	: PodForResource<Pod>(statefulSet.spec.selector.matchLabels)
+	: PodForResource(statefulSet.spec.selector.matchLabels)
 
-open class PodForResource<R: HasMetadata>(private val selectorLabels: Map<String, String>?): Predicate<R> {
+class PodForDaemonSet(daemonSet: DaemonSet)
+	: PodForResource(daemonSet.spec.selector?.matchLabels)
 
-	override fun test(resource: R): Boolean {
-		return selectorLabels?.all { resource.metadata.labels?.entries?.contains(it) ?: false } ?: false
-	}
-}
 
-class PodForDaemonSet(private val resource: DaemonSet) : Predicate<Pod> {
+open class PodForResource(private val selectorLabels: Map<String, String>?): Predicate<Pod> {
 
 	override fun test(pod: Pod): Boolean {
-		return resource.spec.selector?.matchLabels?.all { pod.metadata.labels?.entries?.contains(it) ?: false } ?: false
+		return selectorLabels?.all { pod.metadata.labels?.entries?.contains(it) ?: false } ?: false
 	}
 }
+
+class PodForBuild(private val build: Build)
+	: Predicate<Pod> {
+
+	override fun test(pod: Pod): Boolean {
+		return build.metadata.name == pod.metadata?.labels?.get(BuildOperationsImpl.OPENSHIFT_IO_BUILD_NAME)
+	}
+}
+
+class PodForJob(private val job: Job)
+	: Predicate<Pod> {
+
+	override fun test(pod: Pod): Boolean {
+		return job.metadata.uid == pod.metadata?.labels?.get("controller-uid")
+	}
+}
+

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/KubernetesStructure.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/KubernetesStructure.kt
@@ -16,6 +16,7 @@ import com.intellij.ui.tree.LeafState
 import com.redhat.devtools.intellij.kubernetes.model.IResourceModel
 import com.redhat.devtools.intellij.kubernetes.model.resource.PodForDaemonSet
 import com.redhat.devtools.intellij.kubernetes.model.resource.PodForDeployment
+import com.redhat.devtools.intellij.kubernetes.model.resource.PodForJob
 import com.redhat.devtools.intellij.kubernetes.model.resource.PodForService
 import com.redhat.devtools.intellij.kubernetes.model.resource.PodForStatefulSet
 import com.redhat.devtools.intellij.kubernetes.model.resource.ResourceKind
@@ -72,6 +73,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition
 import io.fabric8.kubernetes.api.model.apps.DaemonSet
 import io.fabric8.kubernetes.api.model.apps.Deployment
 import io.fabric8.kubernetes.api.model.apps.StatefulSet
+import io.fabric8.kubernetes.api.model.batch.v1.Job
 import io.fabric8.kubernetes.api.model.discovery.v1beta1.Endpoint
 import io.fabric8.kubernetes.api.model.storage.StorageClass
 
@@ -264,6 +266,17 @@ class KubernetesStructure(model: IResourceModel) : AbstractTreeStructureContribu
 								.inCurrentNamespace()
 								.list()
 								.sortedBy(resourceName)
+					}
+				},
+				element<Job> {
+					applicableIf { it is Job }
+					childrenKind { NamespacedPodsOperator.KIND }
+					children {
+						model.resources(NamespacedPodsOperator.KIND)
+							.inCurrentNamespace()
+							.filtered(PodForJob(it))
+							.list()
+							.sortedBy(resourceName)
 					}
 				},
 				element<Any> {


### PR DESCRIPTION
fixes #478 

This PR fixes the bug for jobs and cronjobs. Cronjobs create jobs which in turn then show up in **Jobs** and their pods are displayed as children of the job that the `CronJob` created.
![grafik](https://user-images.githubusercontent.com/25126/188200329-c9fa53ca-3102-42fd-ba0b-6ac3abdb121c.png)
