### PR TITLE
TreeUpdater stops listening to resource model when disposed (#486)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/TreeUpdater.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/TreeUpdater.kt
@@ -12,6 +12,8 @@ package com.redhat.devtools.intellij.kubernetes.tree
 
 import com.intellij.ide.util.treeView.AbstractTreeStructure
 import com.intellij.ide.util.treeView.NodeDescriptor
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.Disposer
 import com.intellij.ui.tree.StructureTreeModel
 import com.intellij.ui.tree.TreePathUtil
 import com.redhat.devtools.intellij.kubernetes.actions.getDescriptor
@@ -31,10 +33,17 @@ import javax.swing.tree.TreePath
 class TreeUpdater(
     private val treeModel: StructureTreeModel<AbstractTreeStructure>,
     private val structure: TreeStructure
-) : ModelChangeObservable.IResourceChangeListener {
+) : ModelChangeObservable.IResourceChangeListener, Disposable {
+
+    private var model: IResourceModel? = null
+
+    init {
+        Disposer.register(treeModel, this)
+    }
 
     fun listenTo(model: IResourceModel): TreeUpdater {
         model.addListener(this)
+        this.model = model
         return this
     }
 
@@ -146,4 +155,9 @@ class TreeUpdater(
     private fun hasElement(element: Any, node: TreeNode): Boolean {
         return node.getDescriptor()?.hasElement(element) ?: false
     }
+
+    override fun dispose() {
+        model?.removeListener(this)
+    }
+
 }

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/tree/TreeUpdaterTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/tree/TreeUpdaterTest.kt
@@ -235,6 +235,25 @@ class TreeUpdaterTest {
         }
     }
 
+    @Test
+    fun `#dispose should stop listening to resource model`() {
+        // given
+        updater.listenTo(resourceModel)
+        // when
+        updater.dispose()
+        // then
+        verify(resourceModel).removeListener(updater)
+    }
+
+    @Test
+    fun `#dispose should NOT stop listening to resource model if it never listened to it`() {
+        // given dont listen to resource model
+        // when
+        updater.dispose()
+        // then
+        verify(resourceModel, never()).removeListener(updater)
+    }
+
     private fun node(
         resource: HasMetadata,
         children: List<DefaultMutableTreeNode> = emptyList()


### PR DESCRIPTION
fixes #486 