### PR TITLE
do not call #withName when watching all cr for a crd (#558)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/ClusterResource.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/ClusterResource.kt
@@ -26,7 +26,7 @@ import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClientException
 
 /**
- * A resource that exists on the cluster. May be [pull], [push] etc.
+ * A resource that exists on the cluster. May be [pull]'ed, [push]'ed etc.
  * Notifies listeners of addition, removal and modification if [watch]
  */
 open class ClusterResource protected constructor(

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/NamespacedCustomResourceOperator.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/custom/NamespacedCustomResourceOperator.kt
@@ -38,7 +38,14 @@ open class NamespacedCustomResourceOperator(
     }
 
     override fun watchAll(watcher: Watcher<in GenericKubernetesResource>): Watch? {
-		return watch(namespace, null, watcher)
+		if (namespace == null) {
+			return null
+		}
+		@Suppress("UNCHECKED_CAST")
+		val typedWatcher = watcher as? Watcher<GenericKubernetesResource>? ?: return null
+		return getOperation()
+				?.inNamespace(namespace)
+				?.watch(typedWatcher)
     }
 
 	override fun watch(resource: HasMetadata, watcher: Watcher<in GenericKubernetesResource>): Watch? {
@@ -46,13 +53,16 @@ open class NamespacedCustomResourceOperator(
 		return watch(inNamespace, resource.metadata.name, watcher)
 	}
 
-	private fun watch(namespace: String?, name: String?, watcher: Watcher<in GenericKubernetesResource>): Watch? {
+	private fun watch(namespace: String?, name: String, watcher: Watcher<in GenericKubernetesResource>): Watch? {
 		if (namespace == null) {
 			return null
 		}
 		@Suppress("UNCHECKED_CAST")
 		val typedWatcher = watcher as? Watcher<GenericKubernetesResource>? ?: return null
-		return getOperation()?.inNamespace(namespace)?.withName(name)?.watch(typedWatcher)
+		return getOperation()
+				?.inNamespace(namespace)
+				?.withName(name)
+				?.watch(typedWatcher)
 	}
 
 	override fun delete(resources: List<HasMetadata>): Boolean {

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/model/mocks/ClientMocks.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/model/mocks/ClientMocks.kt
@@ -56,6 +56,7 @@ import io.fabric8.kubernetes.client.dsl.NamespaceableResource
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation
 import io.fabric8.kubernetes.client.dsl.PodResource
 import io.fabric8.kubernetes.client.dsl.Resource
+import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation
 import java.net.URL
 
 
@@ -357,6 +358,12 @@ object ClientMocks {
             .whenever(op).watch(any<Watcher<GenericKubernetesResource>>())
         doReturn(resources)
             .whenever(op).list()
+        val nonNamespaceOperation = mock<NonNamespaceOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>>> {
+            val resourceOp = mock<HasMetadataOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>>>()
+            on { withName(any()) } doReturn resourceOp
+        }
+        doReturn(nonNamespaceOperation)
+            .whenever(op).inNamespace(any())
         return op
     }
 


### PR DESCRIPTION
fixes #558