### PR TITLE
retrieve resources in bkground, check if editor is authorized (#622, #621, #618)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/ClusterResource.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/ClusterResource.kt
@@ -20,6 +20,7 @@ import com.redhat.devtools.intellij.kubernetes.model.util.ResourceException
 import com.redhat.devtools.intellij.kubernetes.model.util.areEqual
 import com.redhat.devtools.intellij.kubernetes.model.util.isNotFound
 import com.redhat.devtools.intellij.kubernetes.model.util.isSameResource
+import com.redhat.devtools.intellij.kubernetes.model.util.isUnauthorized
 import com.redhat.devtools.intellij.kubernetes.model.util.isUnsupported
 import io.fabric8.kubernetes.api.model.HasMetadata
 import io.fabric8.kubernetes.client.KubernetesClient
@@ -190,6 +191,25 @@ open class ClusterResource protected constructor(
         }
         return !(e is KubernetesClientException
             && e.isUnsupported())
+    }
+
+    /**
+     * Returns `true` if this [ClusterResource] is authorized. Returns `false` otherwise.
+     *
+     * @return true if this ClusterResource is authorized
+     *
+     * @see HasMetadata.getKind
+     * @see HasMetadata.getApiVersion
+     */
+    fun isAuthorized(): Boolean {
+        val e = try {
+            pull()
+            null
+        } catch(re: ResourceException) {
+            re.cause
+        }
+        return !(e is KubernetesClientException
+                && e.isUnauthorized())
     }
 
     fun isDeleted(): Boolean {

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResource.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResource.kt
@@ -115,6 +115,9 @@ open class EditorResource(
             !isSupported() ->
                 Error("Unsupported kind ${resource.kind} in version ${resource.apiVersion}")
 
+            !isAuthorized() ->
+                Error("Authentication with cluster failed. Verify username and password, refresh token, etc.")
+
             !hasName(resource)
                     && !hasGenerateName(resource) ->
                 Error("Resource has neither name nor generateName.", null as String?)
@@ -269,6 +272,10 @@ open class EditorResource(
 
     private fun isSupported(): Boolean {
         return clusterResource?.isSupported() ?: false
+    }
+
+    private fun isAuthorized(): Boolean {
+        return clusterResource?.isAuthorized() ?: false
     }
 
     /**

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/actions/DiffAction.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/actions/DiffAction.kt
@@ -14,12 +14,15 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.Progressive
+import com.redhat.devtools.intellij.kubernetes.editor.ResourceEditor
 import com.redhat.devtools.intellij.kubernetes.editor.ResourceEditorFactory
 import com.redhat.devtools.intellij.kubernetes.editor.util.getSelectedFileEditor
 import com.redhat.devtools.intellij.kubernetes.model.Notification
+import com.redhat.devtools.intellij.kubernetes.model.util.KubernetesClientExceptionUtils
+import com.redhat.devtools.intellij.kubernetes.model.util.trimWithEllipsis
 import com.redhat.devtools.intellij.kubernetes.telemetry.TelemetryService
 
-class DiffAction: AnAction() {
+class DiffAction : AnAction() {
 
     companion object {
         const val ID = "com.redhat.devtools.intellij.kubernetes.editor.actions.DiffAction"
@@ -29,18 +32,39 @@ class DiffAction: AnAction() {
         val project = e.project ?: return
         val fileEditor = getSelectedFileEditor(project) ?: return
         val telemetry = TelemetryService.instance.action(TelemetryService.NAME_PREFIX_EDITOR + "diff")
-        com.redhat.devtools.intellij.kubernetes.actions.run("Showing diff...", true,
+        com.redhat.devtools.intellij.kubernetes.actions.run(
+            "Showing diff...", true,
             Progressive {
-                try {
-                    val editor = ResourceEditorFactory.instance.getExistingOrCreate(fileEditor, project) ?: return@Progressive
-                    editor.diff()
-                    TelemetryService.sendTelemetry(editor.getResources(), telemetry)
-                } catch (e: Exception) {
-                    logger<DiffAction>().warn("Could not show diff for resource: ${e.message}", e)
-                    Notification().error("Error showing diff", "Could not show diff editor vs resource from cluster: ${e.message}")
-                    telemetry.error(e).send()
-                }
+                val editor = ResourceEditorFactory.instance.getExistingOrCreate(fileEditor, project)
+                    ?: return@Progressive
+                editor.diff()
+                    .thenApply {
+                        TelemetryService.sendTelemetry(editor.getResources(), telemetry)
+                    }
+                    .exceptionally { completionException ->
+                        val e = completionException.cause as? Exception
+                            ?: completionException as? Exception
+                            ?: return@exceptionally
+                        logger<ResourceEditor>().warn("Could not open diff", e)
+                        telemetry.error(e).send()
+                        notify(e)
+                    }
             })
     }
 
+    private fun notify(e: Exception) {
+        val message = trimWithEllipsis(e.message, 100)
+        val causeMessage = KubernetesClientExceptionUtils.statusMessage(e.cause)
+        Notification()
+            .error(
+                "Could not open diff",
+                if (causeMessage == null) {
+                    message ?: ""
+                } else if (message == null) {
+                    causeMessage
+                } else {
+                    "$message: $causeMessage"
+                }
+            )
+    }
 }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/util/KubernetesClientExceptionUtils.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/util/KubernetesClientExceptionUtils.kt
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.kubernetes.model.util
+
+import io.fabric8.kubernetes.api.model.Status
+import io.fabric8.kubernetes.client.KubernetesClientException
+
+object KubernetesClientExceptionUtils {
+
+    fun statusMessage(t: Throwable?): String? {
+        return status(t)?.message
+    }
+
+    fun status(t: Throwable?): Status? {
+        return if (t is KubernetesClientException) {
+            t.status
+        } else {
+            null
+        }
+    }
+}

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResourceTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResourceTest.kt
@@ -169,6 +169,8 @@ class EditorResourceTest {
         assertThat(editorResource.getState()).isNotInstanceOf(Pushed::class.java)
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         doReturn(true) // after a push: resource exists on cluster
             .whenever(clusterResource).exists()
         doReturn(false) // after a push: resource is not deleted on cluster
@@ -187,6 +189,8 @@ class EditorResourceTest {
         val editorResource = createEditorResource(POD2)
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         assertThat(editorResource.getState()).isNotInstanceOf(Error::class.java)
         doThrow(ResourceException("interference with the force"))
             .whenever(clusterResource).push(any())
@@ -250,6 +254,8 @@ class EditorResourceTest {
         assertThat(editorResource.getState()).isNotInstanceOf(Pushed::class.java)
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         doReturn(true) // after a pull: resource exists on cluster
             .whenever(clusterResource).exists()
         doReturn(false) // after a pull: resource is not deleted on cluster
@@ -269,6 +275,8 @@ class EditorResourceTest {
         editorResource.setLastPushedPulled(POD2) // not modified
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         assertThat(editorResource.getState()).isNotInstanceOf(Error::class.java)
         doThrow(ResourceException("interference with the force"))
             .whenever(clusterResource).pull(any())
@@ -287,6 +295,8 @@ class EditorResourceTest {
         editorResource.setLastPushedPulled(POD2) // modified = (current resource != lastPushedPulled)
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         // when
         val state = editorResource.getState()
         // then
@@ -298,6 +308,8 @@ class EditorResourceTest {
         // given
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         val editorResource = createEditorResource(POD2)
         val error = Error("oh my!")
         editorResource.setState(error)
@@ -348,6 +360,8 @@ class EditorResourceTest {
         val editorResource = createEditorResource(resource)
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         // when
         val state = editorResource.getState()
         // then
@@ -366,6 +380,8 @@ class EditorResourceTest {
         val editorResource = createEditorResource(resource)
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         // when
         val state = editorResource.getState()
         // then
@@ -378,6 +394,8 @@ class EditorResourceTest {
         val editorResource = createEditorResource(POD2)
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         doReturn(true)
             .whenever(clusterResource).isDeleted()
         // when
@@ -392,6 +410,8 @@ class EditorResourceTest {
         val editorResource = createEditorResource(POD2)
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         doReturn(false)
             .whenever(clusterResource).exists()
         // when
@@ -406,6 +426,8 @@ class EditorResourceTest {
         // given
         doReturn(true)
             .whenever(clusterResource).isSupported()
+        doReturn(true)
+            .whenever(clusterResource).isAuthorized()
         doReturn(true) // don't create modified state because it doesnt exist on cluster
             .whenever(clusterResource).exists()
         val editorResource = createEditorResource(POD2)
@@ -429,6 +451,8 @@ class EditorResourceTest {
         doReturn(true)
             .whenever(clusterResource).isSupported()
         doReturn(true)
+            .whenever(clusterResource).isAuthorized()
+        doReturn(true)
             .whenever(clusterResource).isOutdatedVersion(any())
         doReturn(true) // don't return modified state because it doesnt exist
             .whenever(clusterResource).exists()
@@ -446,11 +470,39 @@ class EditorResourceTest {
         doReturn(true)
             .whenever(clusterResource).isSupported()
         doReturn(true)
+            .whenever(clusterResource).isAuthorized()
+        doReturn(true)
             .whenever(clusterResource).isOutdatedVersion(any())
         doReturn(true) // don't return modified state because it doesnt exist
             .whenever(clusterResource).exists()
         editorResource.setLastPushedPulled(POD2) // don't return modified because last pulled pushed is different
         editorResource.setState(mock<Error>())
+        // when
+        val state = editorResource.getState()
+        // then
+        assertThat(state).isInstanceOf(Error::class.java)
+    }
+
+    @Test
+    fun `#getState should return Error if resource is NOT supported on cluster`() {
+        // given
+        val editorResource = createEditorResource(POD2)
+        doReturn(false)
+            .whenever(clusterResource).isSupported()
+        // when
+        val state = editorResource.getState()
+        // then
+        assertThat(state).isInstanceOf(Error::class.java)
+    }
+
+    @Test
+    fun `#getState should return Error if cluster is not authorized`() {
+        // given
+        val editorResource = createEditorResource(POD2)
+        doReturn(true)
+            .whenever(clusterResource).isSupported()
+        doReturn(false)
+            .whenever(clusterResource).isAuthorized()
         // when
         val state = editorResource.getState()
         // then

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/ResourceEditorTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/ResourceEditorTest.kt
@@ -50,6 +50,7 @@ import io.fabric8.kubernetes.api.model.PodBuilder
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClientException
 import io.fabric8.kubernetes.client.utils.Serialization
+import java.util.concurrent.CompletionException
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.yaml.YAMLFileType
 import org.junit.Before
@@ -563,7 +564,7 @@ class ResourceEditorTest {
         doReturn(JsonFileType.INSTANCE)
             .whenever(psiFile).fileType
         // when
-        editor.diff()
+        editor.diff().join()
         // then
         verify(serialize).invoke(any(), eq(JsonFileType.INSTANCE))
     }
@@ -577,13 +578,13 @@ class ResourceEditorTest {
         doReturn(YAMLFileType.YML)
             .whenever(psiFile).fileType
         // when
-        editor.diff()
+        editor.diff().join()
         // then
         verify(serialize).invoke(any(), eq(YAMLFileType.YML))
     }
 
-    @Test
-    fun `#diff should NOT open diff if editor file type is null`() {
+    @Test(expected = CompletionException::class)
+    fun `#diff should throw if editor file type is null`() {
         // given
         givenResources(mapOf(GARGAMEL to NopEditorResourceState()))
         doReturn(GARGAMEL_YAML)
@@ -591,9 +592,8 @@ class ResourceEditorTest {
         doReturn(null)
             .whenever(psiFile).fileType
         // when
-        editor.diff()
+        editor.diff().join()
         // then
-        verify(diff, never()).open(any(), any(), any())
     }
 
     @Test


### PR DESCRIPTION
fixes #622, #621, #618

to test this (using the PR):

**Steps issues #621, #622:**
1. ASSERT: make sure that you are logged into [Developer Sandbox for Red Hat Sandbox](https://developers.redhat.com/developer-sandbox) (start it, copy the login command and run it in your shell)
2. EXEC: edit `~/.kube/config` and trash the token in the user config (example: add an additional char to it)
```
users:
- name: "adietish/api-sandbox-m3-1530-p1-openshiftapps-com:6443"
  user:
    token: "sha256~XXXXX"
```
3. EXEC: launch the plugin
4. EXEC: open an editor with a k8s resource
example: 
```
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
    - name: nginx
      image: nginx
      ports:
        - containerPort: 80
```
**Result:**
The editor shows an error telling you that the authentication failed
<img width="977" alt="image" src="https://github.com/redhat-developer/intellij-kubernetes/assets/25126/3864ac0a-87f0-4eda-b24c-c6ecab2c7209">

5. EXEC: "Dismiss" the notification (link on the right edge) and hit the "Push All" icon in the toolbar
<img width="975" alt="image" src="https://github.com/redhat-developer/intellij-kubernetes/assets/25126/41fec240-da5f-41ca-aa99-e5c799593961">

**Result:**
The editor is not freezing. After a 1,2 secs the authorization error shows up again.

**Steps issue #618**:
1. ASSERT: you have executed the steps above
2. EXEC: in the editor: hit the diff icon in the toolbar
<img width="977" alt="image" src="https://github.com/redhat-developer/intellij-kubernetes/assets/25126/9be6db94-ad88-436b-9814-d0f5537298d9">

**Result:**
An error notification is displayed in the bottom right corner telling you that the diff could not be executed
<img width="382" alt="image" src="https://github.com/redhat-developer/intellij-kubernetes/assets/25126/ed077ebd-2c1e-4141-9781-d1c87e050b09">
