### PR TITLE
list replica sets & replication controllers (#650)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/OperatorFactory.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/OperatorFactory.kt
@@ -24,6 +24,7 @@ import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.Namespa
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.NodesOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.PersistentVolumeClaimsOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.PersistentVolumesOperator
+import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.ReplicaSetsOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.SecretsOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.ServicesOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.StatefulSetsOperator
@@ -47,6 +48,8 @@ object OperatorFactory {
             NamespacesOperator.KIND to ::NamespacesOperator,
             NodesOperator.KIND to ::NodesOperator,
             AllPodsOperator.KIND to ::AllPodsOperator,
+            ReplicaSetsOperator.KIND to ::ReplicaSetsOperator,
+            ReplicationControllersOperator.KIND to ::ReplicationControllersOperator,
             DeploymentsOperator.KIND to ::DeploymentsOperator,
             StatefulSetsOperator.KIND to ::StatefulSetsOperator,
             DaemonSetsOperator.KIND to ::DaemonSetsOperator,
@@ -58,7 +61,6 @@ object OperatorFactory {
             DeploymentConfigsOperator.KIND to ::DeploymentConfigsOperator,
             BuildsOperator.KIND to ::BuildsOperator,
             BuildConfigsOperator.KIND to ::BuildConfigsOperator,
-            ReplicationControllersOperator.KIND to ::ReplicationControllersOperator,
             RoutesOperator.KIND to ::RoutesOperator,
             ServicesOperator.KIND to ::ServicesOperator,
             EndpointsOperator.KIND to ::EndpointsOperator,
@@ -76,6 +78,8 @@ object OperatorFactory {
             NamespacesOperator.KIND to ::NamespacesOperator,
             NodesOperator.KIND to ::NodesOperator,
             AllPodsOperator.KIND to ::AllPodsOperator,
+            ReplicaSetsOperator.KIND to ::ReplicaSetsOperator,
+            ReplicationControllersOperator.KIND to ::ReplicationControllersOperator,
             DeploymentsOperator.KIND to ::DeploymentsOperator,
             StatefulSetsOperator.KIND to ::StatefulSetsOperator,
             DaemonSetsOperator.KIND to ::DaemonSetsOperator,

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/Filters.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/Filters.kt
@@ -11,9 +11,11 @@
 package com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes
 
 import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.api.model.apps.DaemonSet
 import io.fabric8.kubernetes.api.model.apps.Deployment
+import io.fabric8.kubernetes.api.model.apps.ReplicaSet
 import io.fabric8.kubernetes.api.model.apps.StatefulSet
 import io.fabric8.kubernetes.api.model.batch.v1.Job
 import java.util.function.Predicate
@@ -31,6 +33,11 @@ class PodForStatefulSet(statefulSet: StatefulSet)
 class PodForDaemonSet(daemonSet: DaemonSet)
 	: PodForResource(daemonSet.spec.selector?.matchLabels)
 
+class PodForReplicaSet(replicaSet: ReplicaSet)
+	: PodForResource(replicaSet.spec.selector.matchLabels)
+
+class PodForReplicationController(replicationController: ReplicationController)
+	: PodForResource(replicationController.spec.selector)
 
 open class PodForResource(private val selectorLabels: Map<String, String>?): Predicate<Pod> {
 

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/ReplicaSetsOperator.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/resource/kubernetes/ReplicaSetsOperator.kt
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2023 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -8,26 +8,26 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package com.redhat.devtools.intellij.kubernetes.model.resource.openshift
+package com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes
 
 import com.redhat.devtools.intellij.kubernetes.model.client.ClientAdapter
 import com.redhat.devtools.intellij.kubernetes.model.resource.NamespacedOperation
 import com.redhat.devtools.intellij.kubernetes.model.resource.NamespacedResourceOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.ResourceKind
-import io.fabric8.kubernetes.api.model.ReplicationController
+import io.fabric8.kubernetes.api.model.apps.ReplicaSet
 import io.fabric8.kubernetes.client.KubernetesClient
-import io.fabric8.openshift.client.OpenShiftClient
+import io.fabric8.kubernetes.client.impl.AppsAPIGroupClient
 
-class ReplicationControllersOperator(client: ClientAdapter<out KubernetesClient>)
-    : NamespacedResourceOperator<ReplicationController, KubernetesClient>(client.get()) {
+class ReplicaSetsOperator(client: ClientAdapter<out KubernetesClient>)
+    : NamespacedResourceOperator<ReplicaSet, AppsAPIGroupClient>(client.getApps()) {
 
     companion object {
-        val KIND = ResourceKind.create(ReplicationController::class.java)
+        val KIND = ResourceKind.create(ReplicaSet::class.java)
     }
 
     override val kind = KIND
 
-    override fun getOperation(): NamespacedOperation<ReplicationController> {
-        return client.replicationControllers()
+    override fun getOperation(): NamespacedOperation<ReplicaSet> {
+        return client.replicaSets()
     }
 }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/KubernetesDescriptors.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/KubernetesDescriptors.kt
@@ -33,11 +33,13 @@ import io.fabric8.kubernetes.api.model.Node
 import io.fabric8.kubernetes.api.model.PersistentVolume
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim
 import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.Secret
 import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition
 import io.fabric8.kubernetes.api.model.apps.DaemonSet
 import io.fabric8.kubernetes.api.model.apps.Deployment
+import io.fabric8.kubernetes.api.model.apps.ReplicaSet
 import io.fabric8.kubernetes.api.model.apps.StatefulSet
 import io.fabric8.kubernetes.api.model.batch.v1.Job
 import io.fabric8.kubernetes.api.model.batch.v1beta1.CronJob
@@ -79,10 +81,13 @@ object KubernetesDescriptors {
 					|| element is StorageClass
 					|| element is ConfigMap
 					|| element is Secret
-					|| element is GenericKubernetesResource ->
+					|| element is GenericKubernetesResource
+					|| element is ReplicaSet
+					|| element is ReplicationController ->
 					ResourceDescriptor(element as HasMetadata, childrenKind, parent, model, project)
 			element is CustomResourceDefinition ->
 				CustomResourceDefinitionDescriptor(element, parent, model, project)
+
 			else ->
 				null
 		}

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/KubernetesStructure.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/KubernetesStructure.kt
@@ -31,13 +31,17 @@ import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.Persist
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.PodForDaemonSet
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.PodForDeployment
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.PodForJob
+import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.PodForReplicaSet
+import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.PodForReplicationController
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.PodForService
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.PodForStatefulSet
+import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.ReplicaSetsOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.SecretsOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.ServicesOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.StatefulSetsOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.StorageClassesOperator
 import com.redhat.devtools.intellij.kubernetes.model.resource.kubernetes.custom.CustomResourceDefinitionsOperator
+import com.redhat.devtools.intellij.kubernetes.model.resource.openshift.ReplicationControllersOperator
 import com.redhat.devtools.intellij.kubernetes.model.resourceName
 import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.CONFIGURATION
 import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.CONFIG_MAPS
@@ -54,6 +58,8 @@ import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.
 import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.PERSISTENT_VOLUMES
 import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.PERSISTENT_VOLUME_CLAIMS
 import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.PODS
+import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.REPLICASETS
+import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.REPLICATIONCONTROLLERS
 import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.SECRETS
 import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.SERVICES
 import com.redhat.devtools.intellij.kubernetes.tree.KubernetesStructure.Folders.STATEFULSETS
@@ -67,11 +73,13 @@ import io.fabric8.kubernetes.api.model.HasMetadata
 import io.fabric8.kubernetes.api.model.Namespace
 import io.fabric8.kubernetes.api.model.Node
 import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.Secret
 import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition
 import io.fabric8.kubernetes.api.model.apps.DaemonSet
 import io.fabric8.kubernetes.api.model.apps.Deployment
+import io.fabric8.kubernetes.api.model.apps.ReplicaSet
 import io.fabric8.kubernetes.api.model.apps.StatefulSet
 import io.fabric8.kubernetes.api.model.batch.v1.Job
 import io.fabric8.kubernetes.api.model.discovery.v1beta1.Endpoint
@@ -79,20 +87,22 @@ import io.fabric8.kubernetes.api.model.storage.StorageClass
 
 class KubernetesStructure(model: IResourceModel) : AbstractTreeStructureContribution(model) {
     object Folders {
-        val NAMESPACES = NamespacesFolder("Namespaces")
-        val NODES = Folder("Nodes", kind = NodesOperator.KIND)
-        val WORKLOADS = Folder("Workloads", kind = null)
-			val DEPLOYMENTS = Folder("Deployments", kind = DeploymentsOperator.KIND) //  Workloads / Deployments
-			val STATEFULSETS = Folder("StatefulSets", kind = StatefulSetsOperator.KIND) //  Workloads / StatefulSets
-			val DAEMONSETS = Folder("DaemonSets", kind = DaemonSetsOperator.KIND) //  Workloads / DaemonSets
-			val JOBS = Folder("Jobs", kind = JobsOperator.KIND) //  Workloads / Jobs
-			val CRONJOBS = Folder("CronJobs", kind = CronJobsOperator.KIND) //  Workloads / CronJobs
-            val PODS = Folder("Pods", kind = NamespacedPodsOperator.KIND) //  Workloads / Pods
-        val NETWORK = Folder("Network", kind = null)
-            val SERVICES = Folder("Services", kind = ServicesOperator.KIND) // Network / Services
-            val ENDPOINTS = Folder("Endpoints", kind = EndpointsOperator.KIND) // Network / Endpoints
+		val NAMESPACES = NamespacesFolder("Namespaces")
+		val NODES = Folder("Nodes", kind = NodesOperator.KIND)
+		val WORKLOADS = Folder("Workloads", kind = null)
+			val DEPLOYMENTS = Folder("Deployments", kind = DeploymentsOperator.KIND) // Workloads / Deployments
+			val STATEFULSETS = Folder("Stateful Sets", kind = StatefulSetsOperator.KIND) // Workloads / StatefulSets
+			val DAEMONSETS = Folder("Daemon Sets", kind = DaemonSetsOperator.KIND) // Workloads / DaemonSets
+			val JOBS = Folder("Jobs", kind = JobsOperator.KIND) // Workloads / Jobs
+			val CRONJOBS = Folder("Cron Jobs", kind = CronJobsOperator.KIND) // Workloads / CronJobs
+			val PODS = Folder("Pods", kind = NamespacedPodsOperator.KIND) // Workloads / Pods
+			val REPLICASETS = Folder("Replica Sets", kind = ReplicaSetsOperator.KIND) // Workloads / ReplicaSets
+			val REPLICATIONCONTROLLERS = Folder("Replication Controllers", kind = ReplicationControllersOperator.KIND) // Workloads / ReplicationControllers
+		val NETWORK = Folder("Network", kind = null)
+			val SERVICES = Folder("Services", kind = ServicesOperator.KIND) // Network / Services
+			val ENDPOINTS = Folder("Endpoints", kind = EndpointsOperator.KIND) // Network / Endpoints
 			val INGRESS = Folder("Ingress", kind = IngressOperator.KIND) // Network / Ingress
-		val STORAGE = Folder("Storage", kind = null)
+			val STORAGE = Folder("Storage", kind = null)
 			val PERSISTENT_VOLUMES = Folder("Persistent Volumes", kind = PersistentVolumesOperator.KIND) // Storage / Persistent Volumes
 			val PERSISTENT_VOLUME_CLAIMS = Folder("Persistent Volume Claims", kind = PersistentVolumeClaimsOperator.KIND) // Storage / Persistent Volume Claims
 			val STORAGE_CLASSES = Folder("Storage Classes", kind = StorageClassesOperator.KIND) // Storage / Storage Classes
@@ -192,7 +202,9 @@ class KubernetesStructure(model: IResourceModel) : AbstractTreeStructureContribu
 								DAEMONSETS,
 								JOBS,
 								CRONJOBS,
-								PODS)
+								PODS,
+								REPLICASETS,
+								REPLICATIONCONTROLLERS)
 					}
 				},
 				element<Any> {
@@ -298,7 +310,49 @@ class KubernetesStructure(model: IResourceModel) : AbstractTreeStructureContribu
 								.list()
 								.sortedBy(resourceName)
 					}
-				}
+				},
+				element<Any> {
+					applicableIf { it == REPLICASETS }
+					childrenKind { ReplicaSetsOperator.KIND }
+					children {
+						model.resources(ReplicaSetsOperator.KIND)
+							.inCurrentNamespace()
+							.list()
+							.sortedBy(resourceName)
+					}
+				},
+				element<ReplicaSet> {
+					applicableIf { it is ReplicaSet }
+					childrenKind { NamespacedPodsOperator.KIND }
+					children {
+						model.resources(NamespacedPodsOperator.KIND)
+							.inCurrentNamespace()
+							.filtered(PodForReplicaSet(it))
+							.list()
+							.sortedBy(resourceName)
+					}
+				},
+				element<Any> {
+					applicableIf { it == REPLICATIONCONTROLLERS }
+					childrenKind { ReplicationControllersOperator.KIND }
+					children {
+						model.resources(ReplicationControllersOperator.KIND)
+							.inCurrentNamespace()
+							.list()
+							.sortedBy(resourceName)
+					}
+				},
+				element<ReplicationController> {
+					applicableIf { it is ReplicationController }
+					childrenKind { NamespacedPodsOperator.KIND }
+					children {
+						model.resources(NamespacedPodsOperator.KIND)
+							.inCurrentNamespace()
+							.filtered(PodForReplicationController(it))
+							.list()
+							.sortedBy(resourceName)
+					}
+				},
 		)
 	}
 


### PR DESCRIPTION
fixes #650 

both "Replication Controllers" and "Replica Sets" are now listed with their pods:
<img width="480" alt="image" src="https://github.com/redhat-developer/intellij-kubernetes/assets/25126/0ed9223f-b351-43ce-be55-69dd0b761fb9">
