### PR TITLE
use ActionPlaces.TOOLWINDOW_POPUP for resource tree popup menu (#705)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/ResourceTreeToolWindowFactory.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/ResourceTreeToolWindowFactory.kt
@@ -51,7 +51,7 @@ class ResourceTreeToolWindowFactory: ToolWindowFactory, DumbAware {
         toolWindow.contentManager.addContent(content)
 
         val tree = createTree(content, project)
-        PopupHandlerAdapter.install(tree, "com.redhat.devtools.intellij.kubernetes.tree", ActionPlaces.UNKNOWN)
+        PopupHandlerAdapter.install(tree, "com.redhat.devtools.intellij.kubernetes.tree", ActionPlaces.TOOLWINDOW_POPUP)
         panel.setViewportView(tree)
     }
 


### PR DESCRIPTION
fixes #705 