### PR TITLE
fix: removed left indentation to label in 'set current namespace' label (#723)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/dialogs/ResourceNameDialog.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/dialogs/ResourceNameDialog.kt
@@ -56,12 +56,10 @@ class ResourceNameDialog<NAMESPACE: HasMetadata>(
 
         override fun createCenterPanel(): JComponent {
             return JPanel(BorderLayout()).apply {
-                layout = BoxLayout(this, BoxLayout.Y_AXIS)
                 val label = JBLabel("Current $kind:", SwingConstants.LEFT)
-                label.border = JBUI.Borders.empty(0, 0, 10, 0)
-                add(label)
-                add(nameTextField)
-                add(Box.createVerticalBox())
+                label.border = JBUI.Borders.empty(0, 2, 2, 0)
+                add(label, BorderLayout.PAGE_START)
+                add(nameTextField, BorderLayout.CENTER)
             }
         }
 


### PR DESCRIPTION
fixes #723 
<img width="481" alt="image" src="https://github.com/redhat-developer/intellij-kubernetes/assets/25126/ff0a8207-0d20-44a3-8942-aa2a5a61596e">
