### PR TITLE
fix: properly work if listing ns is denied (#717)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/AllContexts.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/AllContexts.kt
@@ -126,7 +126,6 @@ open class AllContexts(
 	override fun setCurrentNamespace(namespace: String): IActiveContext<out HasMetadata, out KubernetesClient>? {
 		val old = this.current ?: return null
 		val newClient = clientFactory.invoke(namespace, old.context.name)
-		throwIfNotAccessible(namespace, newClient.get())
 		val new = setCurrentContext(newClient, old.getWatched())
 		if (new != null) {
 			modelChange.fireCurrentNamespaceChanged(new, old)

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/context/ActiveContext.kt
@@ -119,9 +119,16 @@ abstract class ActiveContext<N : HasMetadata, C : KubernetesClient>(
         return if (!current.isNullOrEmpty()) {
             current
         } else {
-            val allNamespaces = getAllResources(namespaceKind, NO_NAMESPACE)
-            val namespace = allNamespaces.find { namespace:HasMetadata -> DEFAULT_NAMESPACE == namespace.metadata.name } ?: allNamespaces.firstOrNull()
-            return namespace?.metadata?.name
+            return try {
+                val allNamespaces = getAllResources(namespaceKind, NO_NAMESPACE)
+                val namespace =
+                    allNamespaces.find { namespace: HasMetadata -> DEFAULT_NAMESPACE == namespace.metadata.name }
+                        ?: allNamespaces.firstOrNull()
+                namespace?.metadata?.name
+            } catch (e: ResourceException) {
+                logger<ActiveContext<*,*>>().warn("Could not list all namespaces to use 1st as current namespace.", e)
+                null
+            }
         }
     }
 

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/model/AllContextsTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/model/AllContextsTest.kt
@@ -384,20 +384,6 @@ class AllContextsTest {
 		assertThat(contextName.allValues[1]).isEqualTo(activeContext.context.name)
 	}
 
-	@Test(expected = ResourceException::class)
-	fun `#setCurrentNamespace(namespace) should throw if current namespace is forbidden`() {
-		// given
-		val client = client(KubernetesClientException("a disturbance in the force")) // throws upon client#namespaces
-		val clientConfig = clientConfig(currentContext, contexts, configuration)
-		val clientAdapter = clientAdapter(clientConfig, client) // no config so there are no contexts
-		val clientFactory = clientFactory(clientAdapter)
-		val allContexts = TestableAllContexts(modelChange, contextFactory, clientFactory)
-		// when
-		allContexts.setCurrentNamespace("dark side")
-		// then
-		verify(modelChange, never()).fireCurrentNamespaceChanged(anyOrNull(), anyOrNull())
-	}
-
 	@Test
 	fun `#onKubeConfigChanged() should NOT fire if new config is null`() {
 		// given


### PR DESCRIPTION
fixes #717 

**Steps:**
1. ASSERT: use minikube cluster
2. ASSERT: have a file `deployment.yml` with the following content
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: sise-deploy
  labels:
spec:
  replicas: 1
  selector:
    matchLabels:
      app: sise
  template:
    metadata:
      labels:
        app: sise
    spec:
      containers:
      - name: sise
        image: quay.io/openshiftlabs/simpleservice:0.5.0
        ports:
        - containerPort: 9876
        env:
        - name: SIMPLE_SERVICE_VERSION
          value: "0.9"
```
3. EXEC: `kubectl apply -f deployment.yml`
4. ASSERT: a pod `sise-deploy-XXXX` was created (`kubectl get pod`)
5. EXEC: apply the following RBAC rules on minikube
```yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  namespace: default
  name: can-read-pods
rules:
  - apiGroups: [""]
    resources: ["pods"]
    verbs: ["get", "watch", "list"]
---
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: read-pods
  namespace: default
subjects:
  - kind: User
    name: user1
    apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: ClusterRole
  name: can-read-pods
  apiGroup: rbac.authorization.k8s.io
```
6. EXEC: create a new user & context in kube config
```bash
openssl req -new -key user1.key -out user1.csr -subj "/CN=user1/O=group1"
openssl x509 -req -in user1.csr -CA ~/.minikube/ca.crt -CAkey ~/.minikube/ca.key -CAcreateserial -out user1.crt -days 500
kubectl config set-credentials user1 --client-certificate=user1.crt --client-key=user1.key
kubectl config set-context user1-context --cluster=minikube --user=user1
```
7. EXEC: `kubectl config use-context user1-context`
8. EXEC: launch plugin
9. ASSERT: no current namespace is set (`[user1-context]` > `Namespaces` > `current: <none>`)
10. ASSERT: listing namespaces is forbidden (`[user1-context]` > `Namespaces` > child-node: `Forbidden!`)
11. ASSERT: no pods are listed (`[user1-context]` > `Workloads` > `Pods`: children are empty)
12. EXEC: use `Set Current Namespace` in context menu to `Namespaces`, provide `default` in the upcoming dialog and confirm with the `Set` button

**Result:**
current namespace is now `default` ([user1-context] > Namespaces > current: default), Pod "sise-deploy-XXXX" is listed ([user1-context] > Workloads > Pods > sise-deploy-XXXX)


https://github.com/redhat-developer/intellij-kubernetes/assets/25126/83737725-e8b3-4fd7-835e-9e75b1840be8

