### PR TITLE
fix: display evident error msg instead of full details if unauthorized (#732)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResource.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResource.kt
@@ -127,7 +127,7 @@ open class EditorResource(
                 Error("Unsupported kind ${resource.kind} in version ${resource.apiVersion}")
 
             !isAuthorized() ->
-                Error("Authentication with cluster failed. Verify username and password, refresh token, etc.")
+                Error("Unauthorized. Verify username and password, refresh token, etc.")
 
             !hasName(resource)
                     && !hasGenerateName(resource) ->

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/TreeStructure.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/tree/TreeStructure.kt
@@ -28,8 +28,10 @@ import com.redhat.devtools.intellij.kubernetes.model.context.IContext
 import com.redhat.devtools.intellij.kubernetes.model.resource.ResourceKind
 import com.redhat.devtools.intellij.kubernetes.model.util.hasDeletionTimestamp
 import com.redhat.devtools.intellij.kubernetes.model.util.isSameResource
+import com.redhat.devtools.intellij.kubernetes.model.util.isUnauthorized
 import com.redhat.devtools.intellij.kubernetes.model.util.isWillBeDeleted
 import io.fabric8.kubernetes.api.model.HasMetadata
+import io.fabric8.kubernetes.client.KubernetesClientException
 import javax.swing.Icon
 
 /**
@@ -248,7 +250,17 @@ open class TreeStructure(
         project
     ) {
         override fun getLabel(element: java.lang.Exception?): String {
-            return "Error: ${getMessage(element)}"
+            return if (isUnauthorized(element)) {
+                "Unauthorized. Verify username and password, refresh token, etc."
+            } else {
+                "Error: ${getMessage(element)}"
+            }
+        }
+
+        private fun isUnauthorized(e: Exception?): Boolean {
+            val cause = e?.cause
+            return cause is KubernetesClientException
+                    && cause.isUnauthorized()
         }
 
         private fun getMessage(e: Exception?): String {


### PR DESCRIPTION
fixes #732 

<img width="482" alt="image" src="https://github.com/redhat-developer/intellij-kubernetes/assets/25126/f1343a00-7758-4595-93f8-6d3b229bd769">

