### PR TITLE
fix: catch all exceptions when closing the watch (#734)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/ResourceWatch.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/ResourceWatch.kt
@@ -111,8 +111,8 @@ open class ResourceWatch<T>(
             logger<ResourceWatch<*>>().debug("Closing watch for $type resources.")
             watch.close()
             true
-        } catch (e: KubernetesClientException) {
-            logger<ResourceWatch<*>>().warn("Failed to close watch for $type resources.", e)
+        } catch (e: Exception) {
+            logger<ResourceWatch<*>>().warn("Error when closing watch for $type resources.", e)
             false
         }
     }


### PR DESCRIPTION
fixes #734 