### PR TITLE
fix: removed unnecessary elvis operator

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/Base64ValueInlayHintsProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/Base64ValueInlayHintsProvider.kt
@@ -63,7 +63,7 @@ internal class Base64ValueInlayHintsProvider : InlayHintsProvider<NoSettings> {
 			}
 			val content = getContent(element) ?: return true
 			val factory = Base64Presentations.create(content, info, sink, editor) ?: return true
-			factory.create() ?: return true
+			factory.create()
 			return false
 		}
 	}


### PR DESCRIPTION
```
w: file:///Users/adietish/Documents/jboss-workspaces/intellij-kubernetes/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/Base64ValueInlayHintsProvider.kt:66:21 Elvis operator (?:) always returns the left operand of non-nullable type Collection<InlayPresentation>
```