### PR TITLE
chore: allow hotswap in 'runIde' for >=IC-2024.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,11 +110,20 @@ intellijPlatform {
 }
 
 tasks {
+    fun supportsEnhancedClassRedefinition(): Boolean {
+        val platformVersion = findProperty("platformVersion").toString().toFloatOrNull()
+        return platformVersion != null
+                && platformVersion >= 2024.1
+    }
+
     wrapper {
         gradleVersion = providers.gradleProperty("gradleVersion").get()
     }
 
     runIde {
+        if (supportsEnhancedClassRedefinition()) {
+            jvmArgs("-XX:+AllowEnhancedClassRedefinition", "-XX:HotswapAgent=fatjar")
+        }
         systemProperty("com.redhat.devtools.intellij.telemetry.mode", "debug")
     }
 


### PR DESCRIPTION
same feature as in https://github.com/redhat-developer/intellij-openshift-connector/pull/951