### PR TITLE
chore(skip-release): bump intellij-common to 1.9.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 kubernetes-client = "7.1.0"
-devtools-common = "1.9.8-SNAPSHOT"
+devtools-common = "1.9.8"
 jackson-core = "2.17.0"
 commons-lang3 = "3.12.0"
 assertj-core = "3.22.0"


### PR DESCRIPTION
depends on https://github.com/redhat-developer/intellij-common/pull/268