### PR TITLE
fix: allow to edit secrets/configmaps in multi-resource yaml documents (#852)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 kubernetes-client = "7.1.0"
-devtools-common = "1.9.8"
+devtools-common = "1.9.9-SNAPSHOT"
 jackson-core = "2.17.0"
 commons-lang3 = "3.12.0"
 assertj-core = "3.22.0"

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/base64/Base64Presentations.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/base64/Base64Presentations.kt
@@ -18,13 +18,12 @@ import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.redhat.devtools.intellij.common.validation.KubernetesResourceInfo
 import com.redhat.devtools.intellij.common.validation.KubernetesTypeInfo
 import com.redhat.devtools.intellij.kubernetes.balloon.StringInputBalloon
 import com.redhat.devtools.intellij.kubernetes.editor.inlay.base64.Base64Presentations.InlayPresentationsFactory
 import com.redhat.devtools.intellij.kubernetes.editor.inlay.base64.Base64Presentations.create
 import com.redhat.devtools.intellij.kubernetes.editor.util.getBinaryData
-import com.redhat.devtools.intellij.kubernetes.editor.util.getData
+import com.redhat.devtools.intellij.kubernetes.editor.util.getDataValue
 import com.redhat.devtools.intellij.kubernetes.editor.util.isKubernetesResource
 import com.redhat.devtools.intellij.kubernetes.model.util.trimWithEllipsis
 import org.jetbrains.concurrency.runAsync
@@ -44,7 +43,7 @@ object Base64Presentations {
 	fun create(element: PsiElement, info: KubernetesTypeInfo, sink: InlayHintsSink, editor: Editor): InlayPresentationsFactory? {
 		return when {
 			isKubernetesResource(SECRET_RESOURCE_KIND, info) -> {
-				val data = getData(element) ?: return null
+				val data = getDataValue(element) ?: return null
 				StringPresentationsFactory(data, sink, editor)
 			}
 

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/base64/Base64Presentations.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/base64/Base64Presentations.kt
@@ -9,7 +9,7 @@
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
 @file:Suppress("UnstableApiUsage")
-package com.redhat.devtools.intellij.kubernetes.editor.inlay
+package com.redhat.devtools.intellij.kubernetes.editor.inlay.base64
 
 import com.intellij.codeInsight.hints.InlayHintsSink
 import com.intellij.codeInsight.hints.presentation.InlayPresentation
@@ -19,9 +19,10 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.redhat.devtools.intellij.common.validation.KubernetesResourceInfo
+import com.redhat.devtools.intellij.common.validation.KubernetesTypeInfo
 import com.redhat.devtools.intellij.kubernetes.balloon.StringInputBalloon
-import com.redhat.devtools.intellij.kubernetes.editor.inlay.Base64Presentations.InlayPresentationsFactory
-import com.redhat.devtools.intellij.kubernetes.editor.inlay.Base64Presentations.create
+import com.redhat.devtools.intellij.kubernetes.editor.inlay.base64.Base64Presentations.InlayPresentationsFactory
+import com.redhat.devtools.intellij.kubernetes.editor.inlay.base64.Base64Presentations.create
 import com.redhat.devtools.intellij.kubernetes.editor.util.getBinaryData
 import com.redhat.devtools.intellij.kubernetes.editor.util.getData
 import com.redhat.devtools.intellij.kubernetes.editor.util.isKubernetesResource
@@ -40,15 +41,15 @@ object Base64Presentations {
 	private const val SECRET_RESOURCE_KIND = "Secret"
 	private const val CONFIGMAP_RESOURCE_KIND = "ConfigMap"
 
-	fun create(content: PsiElement, info: KubernetesResourceInfo, sink: InlayHintsSink, editor: Editor): InlayPresentationsFactory? {
+	fun create(element: PsiElement, info: KubernetesTypeInfo, sink: InlayHintsSink, editor: Editor): InlayPresentationsFactory? {
 		return when {
 			isKubernetesResource(SECRET_RESOURCE_KIND, info) -> {
-				val data = getData(content) ?: return null
+				val data = getData(element) ?: return null
 				StringPresentationsFactory(data, sink, editor)
 			}
 
 			isKubernetesResource(CONFIGMAP_RESOURCE_KIND, info) -> {
-				val binaryData = getBinaryData(content) ?: return null
+				val binaryData = getBinaryData(element) ?: return null
 				BinaryPresentationsFactory(binaryData, sink, editor)
 			}
 

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/base64/Base64ValueAdapter.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/base64/Base64ValueAdapter.kt
@@ -8,7 +8,7 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package com.redhat.devtools.intellij.kubernetes.editor.inlay
+package com.redhat.devtools.intellij.kubernetes.editor.inlay.base64
 
 import com.intellij.psi.PsiElement
 import com.redhat.devtools.intellij.kubernetes.editor.util.decodeBase64

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/ResourceEditorUtils.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/ResourceEditorUtils.kt
@@ -18,6 +18,7 @@ import com.intellij.json.psi.JsonValue
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.util.text.Strings
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
@@ -87,7 +88,7 @@ fun getKubernetesResourceInfo(file: VirtualFile?, project: Project): KubernetesR
     return try {
         ReadAction.compute<KubernetesResourceInfo, RuntimeException> {
             val psiFile = PsiManager.getInstance(project).findFile(file) ?: return@compute null
-            KubernetesResourceInfo.extractMeta(psiFile)
+            KubernetesResourceInfo.create(psiFile)
         }
     } catch (e: RuntimeException) {
         null
@@ -144,7 +145,7 @@ private fun getElement(key: String, parent: PsiElement): PsiElement? {
  * @param element the PsiElement whose "data" child should be found.
  * @return the PsiElement named "data"
  */
-fun getData(element: PsiElement): PsiElement? {
+fun getDataValue(element: PsiElement): PsiElement? {
     val dataElement = element.children
         .filterIsInstance<PsiNamedElement>()
         .find { it.name == KEY_DATA }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/ResourceEditorUtils.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/ResourceEditorUtils.kt
@@ -65,8 +65,8 @@ fun hasKubernetesResource(file: VirtualFile?, project: Project): Boolean {
  * @param resourceInfo the resource info to inspect
  */
 fun isKubernetesResource(resourceInfo: KubernetesResourceInfo?): Boolean {
-    return resourceInfo?.typeInfo?.apiGroup?.isNotBlank() ?: false
-            && resourceInfo?.typeInfo?.kind?.isNotBlank() ?: false
+    return resourceInfo?.apiGroup?.isNotBlank() ?: false
+            && resourceInfo?.kind?.isNotBlank() ?: false
 }
 
 fun isKubernetesResource(kind: String, info: KubernetesTypeInfo?): Boolean {
@@ -92,49 +92,6 @@ fun getKubernetesResourceInfo(file: VirtualFile?, project: Project): KubernetesR
         }
     } catch (e: RuntimeException) {
         null
-    }
-}
-
-fun getChildren(document: YAMLDocument): List<YAMLPsiElement> {
-    val topLevelValue: YAMLValue = document.topLevelValue ?: return emptyList()
-
-    return when (topLevelValue) {
-        is YAMLMapping ->
-            topLevelValue.keyValues.toList()
-        is YAMLSequence ->
-            topLevelValue.items
-        else ->
-            emptyList()
-    }
-}
-
-fun getChildren(file: JsonFile): List<JsonElement> {
-    return file.allTopLevelValues
-}
-
-/**
- * Returns the [PsiElement] named "metadata" within the children of the given [PsiElement].
- * Only [YAMLKeyValue] and [JsonProperty] are supported. Returns `null` otherwise.
- *
- * @param element the PsiElement whose "metadata" child should be found.
- * @return the PsiElement named "metadata"
- */
-private fun getMetadata(parent: PsiElement): PsiElement? {
-    return getElement(KEY_METADATA, parent)
-}
-
-private fun getElement(key: String, parent: PsiElement): PsiElement? {
-    return when (parent) {
-        is YAMLValue ->
-            parent.children
-                .filterIsInstance<YAMLKeyValue>()
-                .find { it.name == key }
-        is JsonValue ->
-            parent.children.toList()
-                .filterIsInstance<JsonProperty>()
-                .find { it.name == key }
-        else ->
-            null
     }
 }
 

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/telemetry/TelemetryService.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/telemetry/TelemetryService.kt
@@ -56,7 +56,7 @@ object TelemetryService {
     }
 
     fun sendTelemetry(info: KubernetesResourceInfo?, telemetry: TelemetryMessageBuilder.ActionMessage) {
-        telemetry.property(PROP_RESOURCE_KIND, kindOrUnknown(info?.typeInfo)).send()
+        telemetry.property(PROP_RESOURCE_KIND, kindOrUnknown(info?.kind, info?.apiGroup)).send()
     }
 
     fun getKinds(resources: Collection<HasMetadata>): String {
@@ -69,16 +69,13 @@ object TelemetryService {
     }
 
     private fun kindOrUnknown(kind: ResourceKind<*>?): String {
-        return if (kind != null) {
-            "${kind.version}/${kind.kind}"
-        } else {
-            "unknown"
-        }
+        return kindOrUnknown(kind?.kind, kind?.version);
     }
 
-    private fun kindOrUnknown(info: KubernetesTypeInfo?): String {
-        return if (info != null) {
-            "${info.apiGroup}/${info.kind}"
+    private fun kindOrUnknown(kind: String?, apiGroup: String?): String {
+        return if (kind != null
+            && apiGroup != null) {
+            "${kind}/${apiGroup}"
         } else {
             "unknown"
         }

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/validation/KubernetesSchemaProvider.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/validation/KubernetesSchemaProvider.kt
@@ -37,7 +37,7 @@ class KubernetesSchemaProvider(
 				if (psiFile == null) {
 					false
 				} else {
-					val fileInfo = KubernetesTypeInfo.extractMeta(psiFile)
+					val fileInfo = KubernetesTypeInfo.create(psiFile)
 					info == fileInfo
 				}
 			})

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -234,7 +234,10 @@
         <editorTabTitleProvider implementation="com.redhat.devtools.intellij.kubernetes.editor.KubernetesEditorsTabTitleProvider"/>
         <codeInsight.inlayProvider language="yaml"
                                    implementationClass="com.redhat.devtools.intellij.kubernetes.editor.inlay.ResourceEditorInlayHintsProvider"
-                                   id="MarkdownTableInlayProvider"/>
+                                   id="com.redhat.devtools.intellij.kubernetes.editor.yaml.ResourceEditorInlayHintsProvider"/>
+        <codeInsight.inlayProvider language="JSON"
+                                   implementationClass="com.redhat.devtools.intellij.kubernetes.editor.inlay.ResourceEditorInlayHintsProvider"
+                                   id="com.redhat.devtools.intellij.kubernetes.editor.json.ResourceEditorInlayHintsProvider"/>
         <projectConfigurable id="tools.settings.redhat.kubernetes"
                              parentId="tools"
                              displayName="Red Hat Kubernetes"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -233,7 +233,7 @@
         <postStartupActivity implementation="com.redhat.devtools.intellij.kubernetes.KubernetesPluginInitializer" />
         <editorTabTitleProvider implementation="com.redhat.devtools.intellij.kubernetes.editor.KubernetesEditorsTabTitleProvider"/>
         <codeInsight.inlayProvider language="yaml"
-                                   implementationClass="com.redhat.devtools.intellij.kubernetes.editor.inlay.Base64ValueInlayHintsProvider"
+                                   implementationClass="com.redhat.devtools.intellij.kubernetes.editor.inlay.ResourceEditorInlayHintsProvider"
                                    id="MarkdownTableInlayProvider"/>
         <projectConfigurable id="tools.settings.redhat.kubernetes"
                              parentId="tools"

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/Base64PresentationsTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/Base64PresentationsTest.kt
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.kubernetes.editor.inlay
 
 import com.nhaarman.mockitokotlin2.mock
+import com.redhat.devtools.intellij.kubernetes.editor.inlay.base64.Base64Presentations
 import com.redhat.devtools.intellij.kubernetes.editor.mocks.createYAMLKeyValue
 import com.redhat.devtools.intellij.kubernetes.editor.mocks.createYAMLValue
 import com.redhat.devtools.intellij.kubernetes.model.mocks.Mocks.kubernetesResourceInfo
@@ -21,15 +22,9 @@ import org.junit.Test
 
 class Base64PresentationsTest {
 
-	private val secret = kubernetesResourceInfo(
-		"yoda", "light side", kubernetesTypeInfo("Secret", "v1")
-	)
-	private val configMap = kubernetesResourceInfo(
-		"skywalker", "light side", kubernetesTypeInfo("ConfigMap", "v1")
-	)
-	private val pod = kubernetesResourceInfo(
-		"anakin", "light side", kubernetesTypeInfo("Pod", "v1")
-	)
+	private val secret = kubernetesTypeInfo("Secret", "v1")
+	private val configMap = kubernetesTypeInfo("ConfigMap", "v1")
+	private val pod = kubernetesTypeInfo("Pod", "v1")
 
 	private val dataElement = createYAMLKeyValue("data")
 	private val binaryDataElement = createYAMLKeyValue("binaryData")

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/Base64ValueAdapterTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/inlay/Base64ValueAdapterTest.kt
@@ -16,6 +16,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.redhat.devtools.intellij.kubernetes.editor.inlay.base64.Base64ValueAdapter
 import com.redhat.devtools.intellij.kubernetes.editor.mocks.createJsonProperty
 import com.redhat.devtools.intellij.kubernetes.editor.mocks.createJsonPsiFileFactory
 import com.redhat.devtools.intellij.kubernetes.editor.mocks.createProjectWithServices

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/mocks/PsiElementMocks.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/mocks/PsiElementMocks.kt
@@ -15,6 +15,7 @@ import com.intellij.json.psi.JsonProperty
 import com.intellij.json.psi.JsonValue
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import com.nhaarman.mockitokotlin2.any
@@ -51,15 +52,29 @@ fun createJsonProperty(
 	name: String = Random.nextInt().toString(),
 	value: String? = null,
 	parent: JsonProperty? = null,
-	project: Project
+	project: Project = mock()
 ): JsonProperty {
 	val valueElement: JsonValue = mock {
 		on { getText() } doReturn value
 	}
 	return mock {
-		on { getValue() } doReturn valueElement
 		on { getName() } doReturn name
 		on { getValue() } doReturn valueElement
+		on { getParent() } doReturn parent
+		on { getProject() } doReturn project
+	}
+}
+
+fun createJsonObject(
+	name: String = Random.nextInt().toString(),
+	properties: List<JsonProperty> = emptyList(),
+	parent: PsiElement? = null,
+	project: Project = mock()
+): JsonObject {
+	return mock {
+		on { getChildren() } doReturn properties.toTypedArray()
+		on { getPropertyList() } doReturn properties
+		on { getName() } doReturn name
 		on { getParent() } doReturn parent
 		on { getProject() } doReturn project
 	}

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/ResourceEditorUtilsTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/ResourceEditorUtilsTest.kt
@@ -11,11 +11,10 @@
 package com.redhat.devtools.intellij.kubernetes.editor.util
 
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
 import com.redhat.devtools.intellij.common.validation.KubernetesResourceInfo
 import com.redhat.devtools.intellij.common.validation.KubernetesTypeInfo
-import com.redhat.devtools.intellij.kubernetes.editor.mocks.createYAMLDocument
-import com.redhat.devtools.intellij.kubernetes.editor.mocks.createYAMLFile
+import com.redhat.devtools.intellij.kubernetes.editor.mocks.createJsonObject
+import com.redhat.devtools.intellij.kubernetes.editor.mocks.createJsonProperty
 import com.redhat.devtools.intellij.kubernetes.editor.mocks.createYAMLKeyValue
 import com.redhat.devtools.intellij.kubernetes.editor.mocks.createYAMLValue
 import com.redhat.devtools.intellij.kubernetes.model.mocks.Mocks.kubernetesResourceInfo
@@ -86,25 +85,36 @@ class ResourceEditorUtilsTest {
 	}
 
 	@Test
-	fun `#getData should return YAMLKeyValue named data`() {
+	fun `#getDataValue should return YAMLKeyValue named data`() {
 		// given
 		val data = createYAMLKeyValue("data")
 		val parent = createYAMLValue(arrayOf(data))
 		// when
-		val found = getData(parent)
+		val found = getDataValue(parent)
 		// then
 		assertThat(found).isNotNull()
 	}
 
 	@Test
-	fun `#getData should return null if there is no child named data`() {
+	fun `#getDataValue should return null if there is no child named data`() {
 		// given
 		val yoda = createYAMLKeyValue("yoda")
 		val parent = createYAMLValue(arrayOf(yoda))
 		// when
-		val found = getData(parent)
+		val found = getDataValue(parent)
 		// then
 		assertThat(found).isNull()
+	}
+
+	@Test
+	fun `#getDataValue should return JsonProperty named data`() {
+		// given
+		val data = createJsonProperty("data", value = "anakin")
+		val parent = createJsonObject(properties = listOf(data))
+		// when
+		val found = getDataValue(parent)
+		// then
+		assertThat(found?.text).isEqualTo("anakin")
 	}
 
 	@Test

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/ResourceEditorUtilsTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/ResourceEditorUtilsTest.kt
@@ -68,12 +68,9 @@ class ResourceEditorUtilsTest {
 	@Test
 	fun `#isKubernetesResource should return true if info has the given kind`() {
 		// given
-		val kubernetesTypeInfo: KubernetesTypeInfo =
-			kubernetesTypeInfo("jedi", "v1")
-		val kubernetesResourceInfo: KubernetesResourceInfo =
-			kubernetesResourceInfo("yoda", "light side", kubernetesTypeInfo)
+		val kubernetesTypeInfo: KubernetesTypeInfo = kubernetesTypeInfo("jedi", "v1")
 		// when
-		val isKubernetesResource = isKubernetesResource("jedi", kubernetesResourceInfo)
+		val isKubernetesResource = isKubernetesResource("jedi", kubernetesTypeInfo)
 		// then
 		assertThat(isKubernetesResource).isTrue()
 	}
@@ -81,46 +78,11 @@ class ResourceEditorUtilsTest {
 	@Test
 	fun `#isKubernetesResource should return false if info doesnt have the given kind`() {
 		// given
-		val kubernetesTypeInfo: KubernetesTypeInfo =
-			kubernetesTypeInfo("jedi", "v1")
-		val kubernetesResourceInfo: KubernetesResourceInfo =
-			kubernetesResourceInfo("yoda", "light side", kubernetesTypeInfo)
+		val kubernetesTypeInfo: KubernetesTypeInfo = kubernetesTypeInfo("jedi", "v1")
 		// when
-		val isKubernetesResource = isKubernetesResource("sith", kubernetesResourceInfo)
+		val isKubernetesResource = isKubernetesResource("sith", kubernetesTypeInfo)
 		// then
 		assertThat(isKubernetesResource).isFalse()
-	}
-
-	@Test
-	fun `#getContent should return content in YAMLFile`() {
-		// given
-		val value = createYAMLValue(emptyArray())
-		val document = createYAMLDocument(value)
-		val file = createYAMLFile(listOf(document))
-		// when
-		getContent(file)
-		// then
-		verify(file.documents.get(0)).getTopLevelValue()
-	}
-
-	@Test
-	fun `#getContent should return null if YAMLFile has empty list of documents`() {
-		// given
-		val file = createYAMLFile(emptyList())
-		// when
-		val content = getContent(file)
-		// then
-		assertThat(content).isNull()
-	}
-
-	@Test
-	fun `#getContent should return null if YAMLFile has null documents`() {
-		// given
-		val file = createYAMLFile(null)
-		// when
-		val content = getContent(file)
-		// then
-		assertThat(content).isNull()
 	}
 
 	@Test

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/model/mocks/Mocks.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/model/mocks/Mocks.kt
@@ -198,11 +198,16 @@ object Mocks {
     }
 
     fun kubernetesResourceInfo(name: String?, namespace: String?, typeInfo: KubernetesTypeInfo): KubernetesResourceInfo {
-        return mock {
-            on { this.name } doReturn name
-            on { this.namespace } doReturn namespace
-            on { this.typeInfo } doReturn typeInfo
-        }
+        val mock = mock<KubernetesResourceInfo>()
+        whenever(mock.name)
+            .thenReturn(name)
+        whenever(mock.namespace)
+            .thenReturn(namespace)
+        whenever(mock.kind)
+            .thenAnswer { typeInfo.kind } // avoid unfinished stubbing error in mockito
+        whenever(mock.apiGroup)
+            .thenAnswer { typeInfo.apiGroup } // avoid unfinished stubbing error in mockito
+        return mock
     }
 
     fun clientConfig(currentContext: NamedContext?, allContexts: List<NamedContext>): ClientConfig {


### PR DESCRIPTION
fixes #852
fixes #854

depends on https://github.com/redhat-developer/intellij-common/pull/272
depends on https://github.com/redhat-developer/intellij-common/pull/273