### PR TITLE
fix: dont freeze editor when closing editor with offline cluster

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResourceState.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResourceState.kt
@@ -63,6 +63,20 @@ class Error(val title: String, val message: String? = null): EditorResourceState
     }
 }
 
+class Disposed: EditorResourceState() {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        return other is Disposed
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash()
+    }
+}
+
 open class Identical: EditorResourceState()
 
 abstract class Different(val exists: Boolean, val isOutdatedVersion: Boolean): EditorResourceState() {

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/DisposedState.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/DisposedState.kt
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.kubernetes.editor.util
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Interface to manage a disposed state.
+ * The state can be checked and set.
+ * The state is thread safe.
+ */
+interface IDisposedState {
+
+    /**
+     * @return true if the state is disposed, false otherwise
+     */
+    fun isDisposed(): Boolean
+
+    /**
+     * Set the disposed state.
+     * @param disposed the new disposed state
+     * @return true if the state was changed, false otherwise
+     */
+    fun setDisposed(disposed: Boolean): Boolean
+}
+
+class DisposedState: IDisposedState {
+    private val disposed = AtomicBoolean(false)
+
+    override fun isDisposed(): Boolean {
+        return disposed.get()
+    }
+
+    override fun setDisposed(disposed: Boolean): Boolean {
+        return this.disposed.compareAndSet(!disposed, disposed)
+    }
+
+}

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/client/ClientAdapter.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/model/client/ClientAdapter.kt
@@ -77,6 +77,7 @@ abstract class ClientAdapter<C : KubernetesClient>(private val fabric8Client: C)
             context: String? = null,
             clientBuilder: KubernetesClientBuilder? = null,
             createConfig: (context: String?) -> Config = { context ->
+                Config.autoConfigure(context)
                 val config = Config.autoConfigure(context)
                 config.connectionTimeout = TIMEOUT_CONNECTION
                 config.requestTimeout = TIMEOUT_REQUEST

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/ClusterResourceTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/ClusterResourceTest.kt
@@ -32,9 +32,9 @@ import io.fabric8.kubernetes.api.model.StatusBuilder
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClientException
 import io.fabric8.kubernetes.client.Watch
-import java.net.HttpURLConnection
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import java.net.HttpURLConnection
 
 class ClusterResourceTest {
 
@@ -499,7 +499,10 @@ class ClusterResourceTest {
         context: IActiveContext<out HasMetadata, out KubernetesClient>,
         watch: ResourceWatch<HasMetadata>,
         observable: ResourceModelObservable
-        ) : ClusterResource(resource, context, watch, observable) {
+    ) : ClusterResource(
+        resource, context, watch, observable,
+        // run immediately, not async
+        { runnable -> runnable.invoke() }) {
 
         public override var updatedResource: HasMetadata?
             get(): HasMetadata? {

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResourceStateTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResourceStateTest.kt
@@ -114,6 +114,8 @@ class EditorResourceStateTest {
         assertThat(Error("yoda", "is a green gnome")).isNotEqualTo(Error("yoda", "is a jedi"))
         assertThat(Error("obiwan", "is a jedi")).isNotEqualTo(Error("yoda", "is a jedi"))
 
+        assertThat(Error("obiwan", "is a jedi")).isNotEqualTo(Disposed())
+
         assertThat(Error("yoda", "is a jedi")).isNotEqualTo(Identical())
 
         assertThat(Error("yoda", "is a jedi")).isNotEqualTo(Modified(true, true))
@@ -134,10 +136,39 @@ class EditorResourceStateTest {
     }
 
     @Test
+    fun `Disposed is not equal to all the other states`() {
+        // given
+        // when
+        assertThat(Disposed()).isNotEqualTo(Error("yoda", "is a jedi"))
+
+        assertThat(Disposed()).isEqualTo(Disposed())
+
+        assertThat(Disposed()).isNotEqualTo(Identical())
+
+        assertThat(Disposed()).isNotEqualTo(Modified(true, true))
+        assertThat(Disposed()).isNotEqualTo(Modified(true, false))
+        assertThat(Disposed()).isNotEqualTo(Modified(false, false))
+
+        assertThat(Disposed()).isNotEqualTo(DeletedOnCluster())
+
+        assertThat(Disposed()).isNotEqualTo(Outdated())
+
+        assertThat(Disposed()).isNotEqualTo(Created(true))
+        assertThat(Disposed()).isNotEqualTo(Created(false))
+
+        assertThat(Disposed()).isNotEqualTo(Updated(true))
+        assertThat(Disposed()).isNotEqualTo(Updated(false))
+
+        assertThat(Disposed()).isNotEqualTo(Pulled())
+    }
+
+    @Test
     fun `Identical is not equal to all the other states`() {
         // given
         // when
         assertThat(Identical()).isNotEqualTo(Error("yoda", "is a jedi"))
+
+        assertThat(Identical()).isNotEqualTo(Disposed())
 
         assertThat(Identical()).isEqualTo(Identical())
 
@@ -166,6 +197,10 @@ class EditorResourceStateTest {
         assertThat(Modified(true, false)).isNotEqualTo(Error("yoda", "is a jedi"))
         assertThat(Modified(false, false)).isNotEqualTo(Error("yoda", "is a jedi"))
         assertThat(Modified(false, true)).isNotEqualTo(Error("yoda", "is a jedi"))
+
+        assertThat(Modified(true, true)).isNotEqualTo(Disposed())
+        assertThat(Modified(false, true)).isNotEqualTo(Disposed())
+        assertThat(Modified(false, false)).isNotEqualTo(Disposed())
 
         assertThat(Modified(true, true)).isNotEqualTo(Identical())
         assertThat(Modified(true, false)).isNotEqualTo(Identical())
@@ -217,6 +252,8 @@ class EditorResourceStateTest {
         // when
         assertThat(DeletedOnCluster()).isNotEqualTo(Error("darth vader", "is on the dark side"))
 
+        assertThat(DeletedOnCluster()).isNotEqualTo(Disposed())
+
         assertThat(DeletedOnCluster()).isNotEqualTo(Identical())
 
         assertThat(DeletedOnCluster()).isNotEqualTo(Modified(true, true))
@@ -242,6 +279,8 @@ class EditorResourceStateTest {
         // given
         // when
         assertThat(Outdated()).isNotEqualTo(Error("obiwan", "is a jedi"))
+
+        assertThat(Outdated()).isNotEqualTo(Disposed())
 
         assertThat(Outdated()).isNotEqualTo(Identical())
 
@@ -269,6 +308,8 @@ class EditorResourceStateTest {
         // when
         assertThat(Created(true)).isNotEqualTo(Error("darth vader", "is on the dark side"))
         assertThat(Created(false)).isNotEqualTo(Error("darth vader", "is on the dark side"))
+
+        assertThat(Created(false)).isNotEqualTo(Disposed())
 
         assertThat(Created(true)).isNotEqualTo(Identical())
         assertThat(Created(false)).isNotEqualTo(Identical())
@@ -309,6 +350,9 @@ class EditorResourceStateTest {
         assertThat(Updated(true)).isNotEqualTo(Error("darth vader", "is on the dark side"))
         assertThat(Updated(false)).isNotEqualTo(Error("darth vader", "is on the dark side"))
 
+        assertThat(Updated(true)).isNotEqualTo(Disposed())
+        assertThat(Updated(false)).isNotEqualTo(Disposed())
+
         assertThat(Updated(true)).isNotEqualTo(Identical())
         assertThat(Updated(false)).isNotEqualTo(Identical())
 
@@ -346,6 +390,8 @@ class EditorResourceStateTest {
         // given
         // when
         assertThat(Pulled()).isNotEqualTo(Error("darth vader", "is on the dark side"))
+
+        assertThat(Pulled()).isNotEqualTo(Disposed())
 
         assertThat(Pulled()).isNotEqualTo(Identical())
 

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResourcesTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/EditorResourcesTest.kt
@@ -29,10 +29,10 @@ import com.redhat.devtools.intellij.kubernetes.model.mocks.ClientMocks.POD2
 import com.redhat.devtools.intellij.kubernetes.model.mocks.ClientMocks.POD3
 import io.fabric8.kubernetes.api.model.HasMetadata
 import io.fabric8.kubernetes.api.model.PodBuilder
-import java.util.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Test
+import java.util.*
 
 class EditorResourcesTest {
 
@@ -231,7 +231,7 @@ class EditorResourcesTest {
 
     private fun createEditorResourceMock(resource: HasMetadata): EditorResource {
         val editorResource: EditorResource = mock {
-            on { getResource() } doReturn resource
+            on { mock.getResource() } doReturn resource
         }
         // store editorResource mock in list
         editorResources.add(editorResource)

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/DisposedStateTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/DisposedStateTest.kt
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.kubernetes.editor.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class DisposedStateTest {
+
+    @Test
+    fun `#isDisposed should return false initially`() {
+        // given
+        val state = DisposedState()
+        // when
+        val disposed = state.isDisposed()
+        // then
+        assertThat(disposed).isFalse()
+    }
+
+    @Test
+    fun `#isDisposed should return true if it was set to true`() {
+        // given
+        val state = DisposedState()
+        // when
+        val disposed = state.setDisposed(true)
+        // then
+        assertThat(disposed).isTrue()
+    }
+
+    @Test
+    fun `#setDisposed returns true if state was successfully changed`() {
+        // given
+        val state = DisposedState()
+        val disposed = state.isDisposed()
+        // when
+        val changed = state.setDisposed(!disposed) // change state to opposite
+        // then
+        assertThat(changed).isTrue()
+    }
+
+    @Test
+    fun `#setDisposed returns false if state was NOT changed`() {
+        // given
+        val state = DisposedState()
+        val disposed = state.isDisposed()
+        // when
+        val changed = state.setDisposed(disposed) // set the same state again, no change
+        // then
+        assertThat(changed).isFalse()
+    }
+
+}

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/model/ResourceWatchTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/model/ResourceWatchTest.kt
@@ -222,7 +222,11 @@ class ResourceWatchTest {
     class TestableResourceWatch(
         watchOperations: BlockingDeque<WatchOperation<*>>,
         watchOperationsRunner: Runnable = mock()
-    ): ResourceWatch<ResourceKind<out HasMetadata>>(watchOperations, watchOperationsRunner) {
+    ) : ResourceWatch<ResourceKind<out HasMetadata>>(
+        watchOperations,
+        watchOperationsRunner,
+        { runnable: Runnable -> runnable.run() }) {
+
         public override val watches = spy(super.watches)
 
         override fun watch(


### PR DESCRIPTION
fixes #869 

Freezing was caused by race conditions in the locks. Closing the editor disposes the editor resources. Disposing the editor resource closes the cluster connection. When closing the watch, a new resource state is retrieved, this then ended in the resource lock waiting for the connection timeout.
Solved it by introducing a new "Disposed" state which is returned whenever an editor resource is disposed. No further state retrieval occurrs.