### PR TITLE
chore(skip-release): use SimpleDiffRequest to fix verifier complaint (#872)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/settings/Settings.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/settings/Settings.kt
@@ -17,6 +17,7 @@ import com.intellij.openapi.components.SimplePersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
 import com.redhat.devtools.intellij.kubernetes.settings.Settings.SettingsState
 
 @Service
@@ -28,11 +29,15 @@ class Settings: SimplePersistentStateComponent<SettingsState>(SettingsState()) {
 
     companion object {
         const val PROP_EDITOR_SYNC_ENABLED: String = "com.redhat.devtools.intellij.kubernetes.settings.editor.notifications"
+        const val EDITOR_SYNC_ENABLED_DEFAULT = true
 
-        private const val EDITOR_SYNC_ENABLED_DEFAULT = true
-
-        fun getInstance(): Settings {
-            return ApplicationManager.getApplication().service()
+        fun getInstance(): Settings? {
+            return try {
+                ApplicationManager.getApplication().service()
+            } catch (e: Exception) {
+                logger<Settings>().warn("Could not load settings", e)
+                null
+            }
         }
     }
 

--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/settings/SettingsConfigurable.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/settings/SettingsConfigurable.kt
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.kubernetes.settings
 
 import com.intellij.openapi.options.SearchableConfigurable
+import com.redhat.devtools.intellij.kubernetes.settings.Settings.Companion.EDITOR_SYNC_ENABLED_DEFAULT
 import org.jetbrains.annotations.Nls
 import javax.swing.JComponent
 
@@ -51,11 +52,11 @@ internal class SettingsConfigurable: SearchableConfigurable {
     override fun getId(): String = ID
 
     private fun isEditorSyncEnabled(): Boolean {
-        return Settings.getInstance().isEditorSyncEnabled()
+        return Settings.getInstance()?.isEditorSyncEnabled() ?: EDITOR_SYNC_ENABLED_DEFAULT
     }
 
     private fun setEditorSyncEnabled(enabled: Boolean) {
-        Settings.getInstance().setEditorSyncEnabled(enabled)
+        Settings.getInstance()?.setEditorSyncEnabled(enabled)
     }
 
 }

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/ResourceEditorTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/ResourceEditorTest.kt
@@ -363,8 +363,7 @@ class ResourceEditorTest {
         // when
         editor.push(true)
         // then
-        // hides 1) before pushing, 2) after pushing by calling #update
-        verify(notifications, times(2)).hideAll()
+        verify(notifications).hideAll()
     }
 
     @Test


### PR DESCRIPTION
fixes #872 

Remaining issue is erroneously missing telemetry:

```
Compatibility problems (1): 
    #Package 'com.redhat.devtools.intellij.telemetry' is not found
        Package 'com.redhat.devtools.intellij.telemetry' is not found along with its 2 classes.
        Probably the package 'com.redhat.devtools.intellij.telemetry' belongs to a library or dependency that is not resolved by the checker.
        It is also possible, however, that this package was actually removed from a dependency causing the detected problems. Access to unresolved classes at runtime may lead to **NoSuchClassError**.
        The following classes of 'com.redhat.devtools.intellij.telemetry' are not resolved:
          Class com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder.ActionMessage is referenced in
            com.redhat.devtools.intellij.kubernetes.actions.ScaleReplicaAction.aborting(String cause, TelemetryMessageBuilder.ActionMessage telemetry) : void
            com.redhat.devtools.intellij.kubernetes.actions.SetAsCurrentClusterAction.actionPerformed$lambda$0(SetAsCurrentClusterAction this$0, IContext $context, TelemetryMessageBuilder.ActionMessage $telemetry, ProgressIndicator it) : void
            com.redhat.devtools.intellij.kubernetes.actions.TerminalAction.actionPerformed$lambda$2(List $pods, TerminalAction this$0, IResourceModel $model, Project $project, ProgressIndicator it) : void
            com.redhat.devtools.intellij.kubernetes.editor.actions.PushAllAction.actionPerformed$lambda$0(FileEditor $editor, Project $project, TelemetryMessageBuilder.ActionMessage $telemetry, ProgressIndicator it) : void
            com.redhat.devtools.intellij.kubernetes.editor.actions.PushModifiedAction.actionPerformed$lambda$0(FileEditor $editor, Project $project, TelemetryMessageBuilder.ActionMessage $telemetry, ProgressIndicator it) : void
            ...and 40 other places...
          Class com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder is referenced in
            com.redhat.devtools.intellij.kubernetes.actions.OpenDashboardAction.actionPerformed$lambda$0(IActiveContext $currentContext, ProgressIndicator it) : void
            com.redhat.devtools.intellij.kubernetes.actions.SetCurrentProjectAction.onOk$lambda$4$lambda$3(IResourceModel $model, String $name, ProgressIndicator it) : void
            com.redhat.devtools.intellij.kubernetes.actions.UseProjectAction.actionPerformed(AnActionEvent event, TreePath path, Object selectedNode) : void
            com.redhat.devtools.intellij.kubernetes.editor.actions.PullAction.actionPerformed(AnActionEvent e) : void
            com.redhat.devtools.intellij.kubernetes.editor.actions.PushModifiedAction.actionPerformed(AnActionEvent e) : void
            ...and 19 other places...
```