### PR TITLE
fix: dont return match labels if there are only matchExpressions (#878)

### DIFF
--- a/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/SelectorPsiElementUtils.kt
+++ b/src/main/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/SelectorPsiElementUtils.kt
@@ -15,8 +15,10 @@ import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiElement
 import org.jetbrains.yaml.psi.YAMLKeyValue
 import org.jetbrains.yaml.psi.YAMLMapping
+import org.jetbrains.yaml.psi.YAMLScalar
 import org.jetbrains.yaml.psi.YAMLSequence
 import org.jetbrains.yaml.psi.YAMLSequenceItem
+import org.jetbrains.yaml.psi.YAMLValue
 
 private const val KEY_MATCH_LABELS = "matchLabels"
 private const val KEY_MATCH_EXPRESSIONS = "matchExpressions"
@@ -142,11 +144,19 @@ fun YAMLMapping.getMatchLabels(): YAMLMapping? {
     val matchLabels = selector.getKeyValueByKey(KEY_MATCH_LABELS)
     return if (matchLabels != null) {
         matchLabels.value as? YAMLMapping?
-    } else {
+    } else if (selector.getKeyValueByKey(KEY_MATCH_EXPRESSIONS) == null) {
         // Service can have matchLabels as direct children without the 'matchLabels' key.
+        // check if selector has matchExpressions which are not matchLabels
         selector
+    } else {
+        null
     }
 }
+
+private fun YAMLValue.isYamlStringValue(): Boolean {
+    return this is YAMLScalar && this.textValue != null
+}
+
 
 private fun JsonObject.getMatchLabels(): JsonObject? {
     val selector = this.getSelector() ?: return null

--- a/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/SelectorPsiElementUtilsTest.kt
+++ b/src/test/kotlin/com/redhat/devtools/intellij/kubernetes/editor/util/SelectorPsiElementUtilsTest.kt
@@ -68,6 +68,24 @@ class PsiElementExtensionsTest {
     }
 
     @Test
+    fun `#getMatchLabels should return null if selector only has matchExpressions`() {
+        // given
+        val hasMatchExpressions = createYAMLMapping(listOf(
+            createYAMLKeyValue("kind", "Deployment")
+        ))
+        hasMatchExpressions.createMatchExpressions(
+            createYAMLSequence(listOf(
+                createYAMLSequenceItem("jedi", "In", listOf("yoda", "obiwan", "luke"))
+            ))
+        )
+        // when
+        val isNull = yamlElement.getMatchLabels()
+
+        // then
+        assertThat(isNull).isNull()
+    }
+
+    @Test
     fun `#hasMatchLabels should return true when labels exist`() {
         // given
         val matching = createYAMLKeyValue("jedi", "yoda")


### PR DESCRIPTION
fixes #878 